### PR TITLE
feat(header): add Header component with title and tagline support

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@/components/ui/Card';
+import Header from '@/components/ui/Header';
 import { baseColors } from '@/theme/colors';
 import { space } from '@/theme/space';
 import { ScrollView, StyleSheet } from 'react-native';
@@ -10,6 +11,7 @@ export default function TimelineScreen() {
       contentContainerStyle={styles.content}
       showsVerticalScrollIndicator={false}
     >
+      <Header title="Timeline" tagLine="Se alle dine minder her" />
       <Card
         variant="default"
         title="Indflyttergave fra Eline"

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -1,0 +1,53 @@
+import { Text } from '@/components/ui/Text';
+import { baseColors } from '@/theme/colors';
+import { space } from '@/theme/space';
+import { text as textTheme } from '@/theme/type';
+import { CircleUser } from 'lucide-react-native';
+import { StyleSheet, View } from 'react-native';
+
+interface HeaderProps {
+  title: string;
+  tagLine?: string;
+  color?: string;
+}
+
+export default function Header({ title, tagLine, color }: HeaderProps) {
+  return (
+    <View style={[styles.headerContainer]}>
+      <View style={[styles.titleContainer]}>
+        <Text
+          role="heading"
+          style={[styles.title, { color: color ?? baseColors.text }]}
+        >
+          {title}
+        </Text>
+        <CircleUser color={baseColors.text} size={24} />
+      </View>
+      {tagLine && <Text style={[styles.tagLine]}>{tagLine}</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerContainer: {
+    marginBottom: space.lg,
+    marginHorizontal: space.lg,
+    gap: space.sm,
+  },
+  titleContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingBottom: space.sm,
+  },
+  title: {
+    color: baseColors.text,
+    fontSize: textTheme.size.xl,
+    fontFamily: textTheme.family.bold,
+  },
+  tagLine: {
+    color: baseColors.textSoft,
+    fontSize: textTheme.size.sm,
+    fontFamily: textTheme.family.regularItalic,
+  },
+});


### PR DESCRIPTION
This pull request introduces a reusable `Header` component and adds it to the timeline screen to provide a consistent and styled header section. The changes focus on improving UI consistency and code reusability.

**UI Enhancements:**

* Added a new `Header` component in `components/ui/Header.tsx`, which displays a title, optional tagline, and a user icon, with customizable color and styling.
* Updated `app/(tabs)/index.tsx` to import and render the new `Header` component at the top of the timeline screen, providing a title ("Timeline") and tagline ("Se alle dine minder her"). [[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR2) [[2]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR14)