### PR TITLE
feat: add Chip component for selectable UI elements

### DIFF
--- a/components/ui/Chip.tsx
+++ b/components/ui/Chip.tsx
@@ -1,0 +1,60 @@
+import { baseColors } from '@/theme/colors';
+import { space } from '@/theme/space';
+import { text as textTheme } from '@/theme/type';
+import { Pressable, StyleSheet, Text } from 'react-native';
+
+interface ChipProps {
+  label: string;
+  color: string;
+  isSelected?: boolean;
+  setIsSelected?: (selected: boolean) => void;
+}
+
+export default function Chip({
+  label,
+  color,
+  isSelected,
+  setIsSelected,
+}: ChipProps) {
+  return (
+    <Pressable
+      onPress={() => setIsSelected && setIsSelected(!isSelected)}
+      style={[
+        isSelected ? styles.chipSelected : styles.chip,
+        { backgroundColor: isSelected ? color : 'rgb(255, 255, 255, 0.5)' },
+      ]}
+    >
+      <Text style={isSelected ? styles.selectedLabel : styles.label}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    paddingHorizontal: space.lg,
+    paddingVertical: space.xs,
+    borderRadius: 16,
+    alignSelf: 'flex-start',
+    borderColor: 'rgb(107, 101, 96, 0.19)',
+    borderWidth: 1,
+  },
+  chipSelected: {
+    paddingHorizontal: space.lg,
+    paddingVertical: space.xs,
+    borderRadius: 16,
+    alignSelf: 'flex-start',
+    borderWidth: 1,
+  },
+  label: {
+    color: baseColors.textSoft,
+    fontSize: textTheme.size.sm,
+    fontFamily: textTheme.family.semiBold,
+  },
+  selectedLabel: {
+    color: baseColors.bg,
+    fontSize: textTheme.size.sm,
+    fontFamily: textTheme.family.semiBold,
+  },
+});


### PR DESCRIPTION
This pull request introduces a new reusable `Chip` component for the UI. The `Chip` is a pressable element that can display a label, indicate selection state, and trigger a callback when toggled.

UI Components:

* Added a new `Chip` component in `components/ui/Chip.tsx` that supports customizable label, color, selection state, and selection toggle callback. The component uses styles and theme variables for consistent appearance.