### PR TITLE
Image component

### DIFF
--- a/components/ui/Chip.tsx
+++ b/components/ui/Chip.tsx
@@ -8,6 +8,7 @@ interface ChipProps {
   color: string;
   isSelected?: boolean;
   setIsSelected?: (selected: boolean) => void;
+  style: any;
 }
 
 export default function Chip({
@@ -15,11 +16,13 @@ export default function Chip({
   color,
   isSelected,
   setIsSelected,
+  style,
 }: ChipProps) {
   return (
     <Pressable
       onPress={() => setIsSelected && setIsSelected(!isSelected)}
       style={[
+        style,
         isSelected ? styles.chipSelected : styles.chip,
         { backgroundColor: isSelected ? color : 'rgb(255, 255, 255, 0.5)' },
       ]}
@@ -45,6 +48,7 @@ const styles = StyleSheet.create({
     paddingVertical: space.xs,
     borderRadius: 16,
     alignSelf: 'flex-start',
+    borderColor: 'transparent',
     borderWidth: 1,
   },
   label: {

--- a/components/ui/Image.tsx
+++ b/components/ui/Image.tsx
@@ -1,0 +1,136 @@
+import { baseColors } from '@/theme/colors';
+import { text } from '@/theme/type';
+import { Image as ExpoImage } from 'expo-image';
+import { StyleSheet, View } from 'react-native';
+import Chip from './Chip';
+import { Text } from './Text';
+
+interface ImageProps {
+  source: string;
+  variant?: 'default' | 'large' | 'polaroid';
+  chip?: {
+    label: string;
+    color: string;
+  };
+  polaroid?: {
+    color: string;
+    date: string;
+  };
+}
+
+export default function Image({
+  source,
+  variant = 'default',
+  chip,
+  polaroid,
+}: ImageProps) {
+  const imageVariant = variant;
+
+  switch (imageVariant) {
+    case 'large':
+      return <LargeImage source={source} chip={chip} />;
+    case 'polaroid':
+      return <PolaroidImage source={source} polaroid={polaroid} />;
+    default:
+      return <DefaultImage source={source} />;
+  }
+}
+
+function DefaultImage({ source }: ImageProps) {
+  return (
+    <ExpoImage source={{ uri: source }} style={styles.imageContainerDefault} />
+  );
+}
+
+function LargeImage({ source, chip }: ImageProps) {
+  return (
+    <View style={styles.imageContainerLarge}>
+      <ExpoImage source={{ uri: source }} style={styles.imageLarge} />
+      <Chip
+        style={styles.chip}
+        isSelected
+        label={chip?.label || ''}
+        color={chip?.color || ''}
+      />
+    </View>
+  );
+}
+
+function PolaroidImage({ source, polaroid }: ImageProps) {
+  let randomRotation = Math.random() * 10 - 5; // Random rotation between -5 and 5 degrees
+  return (
+    <View
+      style={[
+        styles.polaroidContainer,
+        {
+          transform: [{ rotate: `${randomRotation}deg` }],
+        },
+      ]}
+    >
+      <ExpoImage source={{ uri: source }} style={styles.imagePolaroid} />
+      <View style={[styles.pin, { backgroundColor: polaroid?.color }]}></View>
+      <Text style={styles.text}>{polaroid?.date}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  imageContainerDefault: {
+    width: 110,
+    height: 110,
+    objectFit: 'cover',
+    borderRadius: 14,
+  },
+
+  imageContainerLarge: {
+    width: '100%',
+    height: 320,
+    position: 'relative',
+  },
+  imageLarge: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+  },
+  chip: {
+    position: 'absolute',
+    bottom: 24,
+    left: 16,
+  },
+
+  polaroidContainer: {
+    width: 175,
+    height: 200,
+    // transform: [{ rotate: '-5deg' }],
+    backgroundColor: baseColors.text,
+    padding: 12.5,
+    paddingBottom: 100,
+    position: 'relative',
+    borderRadius: 4,
+  },
+  imagePolaroid: {
+    width: 150,
+    height: 150,
+    objectFit: 'cover',
+    borderRadius: 2,
+  },
+  text: {
+    color: baseColors.textMuted,
+    fontFamily: text.family.regularItalic,
+    fontSize: text.size.xs,
+    textAlign: 'center',
+    paddingBottom: 4,
+    lineHeight: text.lineHeight.xs,
+  },
+  pin: {
+    width: 20,
+    height: 20,
+    backgroundColor: 'white',
+    borderRadius: 10,
+    position: 'absolute',
+    top: -10,
+    left: '50%',
+    marginHorizontal: 'auto',
+    boxShadow: `0 2px 4px 0 ${baseColors.shadow}`,
+  },
+});


### PR DESCRIPTION
This pull request introduces a new, flexible `Image` component with support for multiple display variants and improves the `Chip` component to allow custom styling. The changes enhance UI modularity and visual options for image presentation.

**New `Image` component and variants:**

* Added a new `Image` component (`components/ui/Image.tsx`) that supports `default`, `large`, and `polaroid` variants, each with tailored layouts and styling. The `large` variant can display a `Chip` overlay, and the `polaroid` variant includes a date and decorative pin.

**Enhancements to `Chip` component:**

* Updated the `ChipProps` interface and `Chip` component to accept a `style` prop, enabling external style overrides for more flexible use in various layouts.
* Set the default border color of the `Chip` component to `transparent` for improved appearance when unselected.