### PR TITLE
Add reusable event photo picker and fullscreen image viewer

### DIFF
--- a/app/(tabs)/events/new.tsx
+++ b/app/(tabs)/events/new.tsx
@@ -1,16 +1,20 @@
 import { useState } from 'react';
 
+import {
+  AddImageField,
+  type SelectedImage,
+} from '@/components/ui/AddImageField';
 import { DatePicker } from '@/components/DatePicker';
 import { Input } from '@/components/ui/Input';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
-import { text } from '@/theme/type';
 import { ScrollView, StyleSheet, View } from 'react-native';
 
 export default function NewEventScreen() {
   const [title, setTitle] = useState('');
   const [eventDate, setEventDate] = useState(new Date(2026, 3, 14));
   const [description, setDescription] = useState('');
+  const [photos, setPhotos] = useState<SelectedImage[]>([]);
 
   return (
     <ScrollView
@@ -46,6 +50,11 @@ export default function NewEventScreen() {
           minRows={4}
           value={description}
         />
+        <AddImageField
+          color={sectionColors.events}
+          value={photos}
+          onChange={setPhotos}
+        />
       </View>
     </ScrollView>
   );
@@ -53,7 +62,6 @@ export default function NewEventScreen() {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     backgroundColor: baseColors.bg,
   },
   content: {
@@ -61,27 +69,6 @@ const styles = StyleSheet.create({
     paddingTop: space.lg,
     paddingBottom: space.xxl,
     gap: space.xl,
-  },
-  hero: {
-    gap: space.sm,
-  },
-  eyebrow: {
-    color: baseColors.textSoft,
-    fontFamily: text.family.medium,
-    fontSize: text.size.sm,
-    lineHeight: text.lineHeight.sm,
-  },
-  title: {
-    color: baseColors.text,
-    fontFamily: text.family.bold,
-    fontSize: text.size.xl,
-    lineHeight: text.lineHeight.xl,
-  },
-  description: {
-    color: baseColors.textSoft,
-    fontFamily: text.family.regular,
-    fontSize: text.size.md,
-    lineHeight: 24,
   },
   form: {
     gap: space.xl,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,6 +9,7 @@ import {
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { baseColors } from '../theme/colors';
 
 export default function RootLayout() {
@@ -26,7 +27,7 @@ export default function RootLayout() {
   }
 
   return (
-    <>
+    <SafeAreaProvider>
       <StatusBar style="light" />
       <Stack
         screenOptions={{
@@ -37,6 +38,6 @@ export default function RootLayout() {
         <Stack.Screen name="(tabs)" />
         <Stack.Screen name="+not-found" />
       </Stack>
-    </>
+    </SafeAreaProvider>
   );
 }

--- a/components/ui/AddImageField.tsx
+++ b/components/ui/AddImageField.tsx
@@ -1,0 +1,378 @@
+import { baseColors, sectionColors } from '@/theme/colors';
+import { radius } from '@/theme/radius';
+import { space } from '@/theme/space';
+import { text as textTheme } from '@/theme/type';
+import { Image } from 'expo-image';
+import * as ImagePicker from 'expo-image-picker';
+import { Camera, Plus, X } from 'lucide-react-native';
+import { useState } from 'react';
+import {
+  Alert,
+  LayoutChangeEvent,
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+  type ViewProps,
+} from 'react-native';
+
+import { Text } from './Text';
+
+export type ImageUploadStatus = 'local' | 'uploading' | 'uploaded' | 'failed';
+
+const DEFAULT_MAX_IMAGES = 6;
+const GRID_COLUMNS = 3;
+const GRID_GAP = space.md;
+
+export type SelectedImage = {
+  id: string;
+  uri: string;
+  assetId?: string | null;
+  fileName?: string | null;
+  mimeType?: string | null;
+  width?: number;
+  height?: number;
+  fileSize?: number;
+  storagePath?: string | null;
+  publicUrl?: string | null;
+  uploadStatus?: ImageUploadStatus;
+};
+
+interface AddImageFieldProps extends ViewProps {
+  value: SelectedImage[];
+  onChange: (next: SelectedImage[]) => void;
+  label?: string;
+  color?: string;
+  allowsMultipleSelection?: boolean;
+  maxImages?: number;
+  disabled?: boolean;
+  onRequestUpload?: (images: SelectedImage[]) => void;
+}
+
+function createSelectedImage(
+  asset: ImagePicker.ImagePickerAsset,
+): SelectedImage {
+  const id = asset.assetId ?? asset.uri;
+
+  return {
+    id,
+    uri: asset.uri,
+    assetId: asset.assetId ?? null,
+    fileName: asset.fileName ?? null,
+    mimeType: asset.mimeType ?? null,
+    width: asset.width > 0 ? asset.width : undefined,
+    height: asset.height > 0 ? asset.height : undefined,
+    fileSize: asset.fileSize,
+    storagePath: null,
+    publicUrl: null,
+    uploadStatus: 'local',
+  };
+}
+
+function getNewImages(
+  currentImages: SelectedImage[],
+  pickedImages: SelectedImage[],
+): SelectedImage[] {
+  const existingIds = new Set(currentImages.map((image) => image.id));
+
+  return pickedImages.filter((image) => !existingIds.has(image.id));
+}
+
+export function AddImageField({
+  value,
+  onChange,
+  label = 'Photos',
+  color = sectionColors.events,
+  allowsMultipleSelection = true,
+  maxImages = DEFAULT_MAX_IMAGES,
+  disabled = false,
+  onRequestUpload,
+  style,
+  ...rest
+}: AddImageFieldProps) {
+  const [isPicking, setIsPicking] = useState(false);
+  const [gridWidth, setGridWidth] = useState(0);
+  const images = value.slice(0, maxImages);
+  const remainingSlots = Math.max(maxImages - images.length, 0);
+  const canAddMore = remainingSlots > 0;
+  const isDisabled = disabled || isPicking;
+  const itemSize =
+    gridWidth > GRID_GAP * (GRID_COLUMNS - 1)
+      ? (gridWidth - GRID_GAP * (GRID_COLUMNS - 1)) / GRID_COLUMNS
+      : 0;
+
+  function handleGridLayout(event: LayoutChangeEvent) {
+    const nextWidth = Math.round(event.nativeEvent.layout.width);
+
+    setGridWidth((currentWidth) =>
+      currentWidth === nextWidth ? currentWidth : nextWidth,
+    );
+  }
+
+  async function ensureMediaPermission() {
+    if (Platform.OS === 'web') {
+      return true;
+    }
+
+    const currentPermission =
+      await ImagePicker.getMediaLibraryPermissionsAsync();
+
+    if (currentPermission.granted) {
+      return true;
+    }
+
+    const nextPermission = currentPermission.canAskAgain
+      ? await ImagePicker.requestMediaLibraryPermissionsAsync()
+      : currentPermission;
+
+    if (nextPermission.granted) {
+      return true;
+    }
+
+    Alert.alert(
+      'Photo access needed',
+      'Allow photo library access to add images to this event.',
+    );
+    return false;
+  }
+
+  async function handleAddImages() {
+    if (isDisabled || !canAddMore) {
+      return;
+    }
+
+    setIsPicking(true);
+
+    try {
+      const hasPermission = await ensureMediaPermission();
+
+      if (!hasPermission) {
+        return;
+      }
+
+      const result = await ImagePicker.launchImageLibraryAsync({
+        allowsMultipleSelection: allowsMultipleSelection && remainingSlots > 1,
+        mediaTypes: ['images'],
+        quality: 1,
+        selectionLimit: remainingSlots,
+      });
+
+      if (result.canceled || !result.assets?.length) {
+        return;
+      }
+
+      const pickedImages = result.assets.map(createSelectedImage);
+      const newImages = getNewImages(images, pickedImages).slice(
+        0,
+        remainingSlots,
+      );
+
+      if (newImages.length === 0) {
+        return;
+      }
+
+      const nextImages = [...images, ...newImages];
+      onChange(nextImages);
+      onRequestUpload?.(newImages);
+    } catch {
+      Alert.alert('Could not open photos', 'Please try again in a moment.');
+    } finally {
+      setIsPicking(false);
+    }
+  }
+
+  function handleRemoveImage(imageId: string) {
+    onChange(images.filter((image) => image.id !== imageId));
+  }
+
+  return (
+    <View {...rest} style={[styles.field, style]}>
+      <View style={styles.header}>
+        <Text style={styles.label}>
+          {label} <Text style={styles.count}>({images.length})</Text>
+        </Text>
+
+        {canAddMore ? (
+          <Pressable
+            accessibilityHint="Opens your photo library"
+            accessibilityLabel={`Add a photo to ${label.toLowerCase()}`}
+            accessibilityRole="button"
+            disabled={isDisabled}
+            hitSlop={space.sm}
+            onPress={handleAddImages}
+            style={({ pressed }) => [
+              styles.headerAction,
+              pressed && !isDisabled ? styles.pressed : null,
+              isDisabled ? styles.disabled : null,
+            ]}
+          >
+            <Text style={[styles.headerActionText, { color }]}>
+              + Add Photo
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      {images.length === 0 ? (
+        <Pressable
+          accessibilityHint="Opens your photo library"
+          accessibilityLabel={`Add photos to ${label.toLowerCase()}`}
+          accessibilityRole="button"
+          disabled={isDisabled}
+          onPress={handleAddImages}
+          style={({ pressed }) => [
+            styles.emptyTrigger,
+            pressed && !isDisabled ? styles.pressed : null,
+            isDisabled ? styles.disabled : null,
+          ]}
+        >
+          <Camera
+            color={baseColors.textMuted}
+            size={textTheme.size.xl + space.sm}
+            strokeWidth={1.75}
+          />
+          <Text style={styles.emptyText}>Tap to add photos</Text>
+        </Pressable>
+      ) : (
+        <View onLayout={handleGridLayout} style={styles.grid}>
+          {images.map((image) => (
+            <View
+              key={image.id}
+              style={[styles.gridItem, { height: itemSize, width: itemSize }]}
+            >
+              <Image
+                source={{ uri: image.publicUrl ?? image.uri }}
+                style={styles.preview}
+                contentFit="cover"
+              />
+              <Pressable
+                accessibilityHint="Removes this photo from the event draft"
+                accessibilityLabel={`Remove ${image.fileName ?? 'photo'}`}
+                accessibilityRole="button"
+                hitSlop={space.sm}
+                onPress={() => handleRemoveImage(image.id)}
+                style={({ pressed }) => [
+                  styles.removeButton,
+                  pressed ? styles.pressed : null,
+                ]}
+              >
+                <X color={baseColors.text} size={14} strokeWidth={2.25} />
+              </Pressable>
+            </View>
+          ))}
+
+          {canAddMore ? (
+            <Pressable
+              accessibilityHint="Opens your photo library"
+              accessibilityLabel="Add another photo"
+              accessibilityRole="button"
+              disabled={isDisabled}
+              onPress={handleAddImages}
+              style={({ pressed }) => [
+                styles.compactTrigger,
+                styles.gridItem,
+                { height: itemSize, width: itemSize },
+                pressed && !isDisabled ? styles.pressed : null,
+                isDisabled ? styles.disabled : null,
+              ]}
+            >
+              <Plus color={baseColors.textMuted} size={18} strokeWidth={1.75} />
+            </Pressable>
+          ) : null}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  field: {
+    gap: space.md,
+  },
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  label: {
+    color: baseColors.text,
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.lg,
+    lineHeight: textTheme.lineHeight.lg,
+  },
+  count: {
+    fontVariant: ['tabular-nums'],
+  },
+  headerAction: {
+    borderRadius: radius.full,
+    paddingHorizontal: space.xs,
+    paddingVertical: space.xxs,
+  },
+  headerActionText: {
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.lg,
+    lineHeight: textTheme.lineHeight.lg,
+  },
+  emptyTrigger: {
+    alignItems: 'center',
+    backgroundColor: baseColors.card,
+    borderColor: 'rgba(107, 101, 96, 0.4)',
+    borderCurve: 'continuous',
+    borderRadius: radius.xl,
+    borderStyle: 'dashed',
+    borderWidth: 2,
+    gap: space.sm,
+    justifyContent: 'center',
+    minHeight: space.xxl * 5,
+    paddingHorizontal: space.xl,
+    paddingVertical: space.xxl + space.sm,
+  },
+  emptyText: {
+    color: baseColors.textMuted,
+    fontFamily: textTheme.family.regular,
+    fontSize: textTheme.size.md,
+    lineHeight: textTheme.lineHeight.md,
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: space.md,
+  },
+  gridItem: {
+    backgroundColor: baseColors.card,
+    borderCurve: 'continuous',
+    borderRadius: radius.lg,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  preview: {
+    height: '100%',
+    width: '100%',
+  },
+  removeButton: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(26, 26, 26, 0.78)',
+    borderColor: 'rgba(245, 240, 236, 0.18)',
+    borderRadius: radius.full,
+    borderWidth: 1,
+    height: 28,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: space.xs,
+    top: space.xs,
+    width: 28,
+  },
+  compactTrigger: {
+    alignItems: 'center',
+    borderColor: 'rgba(107, 101, 96, 0.4)',
+    borderStyle: 'dashed',
+    borderWidth: 2,
+    justifyContent: 'center',
+  },
+  pressed: {
+    opacity: 0.82,
+  },
+  disabled: {
+    opacity: 0.45,
+  },
+});

--- a/components/ui/AddImageField.tsx
+++ b/components/ui/AddImageField.tsx
@@ -2,6 +2,7 @@ import { baseColors, sectionColors } from '@/theme/colors';
 import { radius } from '@/theme/radius';
 import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
+import Constants from 'expo-constants';
 import { Image } from 'expo-image';
 import * as ImagePicker from 'expo-image-picker';
 import {
@@ -15,16 +16,17 @@ import { useEffect, useState } from 'react';
 import {
   Alert,
   LayoutChangeEvent,
-  Linking,
   Modal,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
   View,
   type ViewProps,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 
 import { Text } from './Text';
 
@@ -33,7 +35,6 @@ export type ImageUploadStatus = 'local' | 'uploading' | 'uploaded' | 'failed';
 const DEFAULT_MAX_IMAGES = 6;
 const GRID_COLUMNS = 3;
 const GRID_GAP = space.md;
-const APP_NAME = 'Memoir';
 
 export type SelectedImage = {
   id: string;
@@ -90,26 +91,6 @@ function getNewImages(
   return pickedImages.filter((image) => !existingIds.has(image.id));
 }
 
-async function openAppSettings() {
-  try {
-    await Linking.openSettings();
-  } catch {
-    Alert.alert('Could not open settings', getPhotoAccessInstructions());
-  }
-}
-
-function getPhotoAccessInstructions() {
-  if (Platform.OS === 'ios') {
-    return `Open Settings > ${APP_NAME} > Photos, then choose Full Access or Limited Access.`;
-  }
-
-  if (Platform.OS === 'android') {
-    return `Open Settings > Apps > ${APP_NAME} > Permissions > Photos and videos, then tap Allow.`;
-  }
-
-  return 'Open your device settings and allow photo library access for this app.';
-}
-
 export function AddImageField({
   value,
   onChange,
@@ -126,6 +107,7 @@ export function AddImageField({
   const [isPicking, setIsPicking] = useState(false);
   const [gridWidth, setGridWidth] = useState(0);
   const [activeImageIndex, setActiveImageIndex] = useState<number | null>(null);
+  const insets = useSafeAreaInsets();
   const isEditable = editable ?? Boolean(onChange);
   const resolvedMaxImages =
     maxImages ??
@@ -168,45 +150,6 @@ export function AddImageField({
     );
   }
 
-  async function ensureMediaPermission() {
-    if (Platform.OS === 'web') {
-      return true;
-    }
-
-    const currentPermission =
-      await ImagePicker.getMediaLibraryPermissionsAsync();
-
-    if (currentPermission.granted) {
-      return true;
-    }
-
-    const nextPermission = currentPermission.canAskAgain
-      ? await ImagePicker.requestMediaLibraryPermissionsAsync()
-      : currentPermission;
-
-    if (nextPermission.granted) {
-      return true;
-    }
-
-    Alert.alert(
-      'Photo access needed',
-      `Allow photo library access to add images to this event.\n\n${getPhotoAccessInstructions()}`,
-      [
-        {
-          text: 'Not now',
-          style: 'cancel',
-        },
-        {
-          text: 'Open app settings',
-          onPress: () => {
-            void openAppSettings();
-          },
-        },
-      ],
-    );
-    return false;
-  }
-
   async function handleAddImages() {
     if (!isEditable || !onChange || isDisabled || !canAddMore) {
       return;
@@ -215,12 +158,6 @@ export function AddImageField({
     setIsPicking(true);
 
     try {
-      const hasPermission = await ensureMediaPermission();
-
-      if (!hasPermission) {
-        return;
-      }
-
       const result = await ImagePicker.launchImageLibraryAsync({
         allowsMultipleSelection: allowsMultipleSelection && remainingSlots > 1,
         mediaTypes: ['images'],
@@ -246,7 +183,12 @@ export function AddImageField({
       onChange(nextImages);
       onRequestUpload?.(newImages);
     } catch {
-      Alert.alert('Could not open photos', 'Please try again in a moment.');
+      Alert.alert(
+        'Could not open photos',
+        Constants.appOwnership === 'expo'
+          ? 'Expo Go could not open the system photo picker. Close and reopen Expo Go, then try again.'
+          : 'Please try again in a moment.',
+      );
     } finally {
       setIsPicking(false);
     }
@@ -423,11 +365,14 @@ export function AddImageField({
       <Modal
         animationType="fade"
         onRequestClose={handleCloseViewer}
+        statusBarTranslucent
         transparent
         visible={activeImageIndex !== null}
       >
-        <SafeAreaView edges={['top', 'bottom']} style={styles.viewerSafeArea}>
-          <View style={styles.viewerHeader}>
+        <SafeAreaView edges={['bottom']} style={styles.viewerSafeArea}>
+          <View
+            style={[styles.viewerHeader, { paddingTop: insets.top + space.md }]}
+          >
             <Pressable
               accessibilityHint="Closes the photo viewer"
               accessibilityLabel="Close photo viewer"
@@ -644,7 +589,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingHorizontal: space.lg,
-    paddingTop: space.sm,
   },
   viewerHeaderButton: {
     alignItems: 'center',

--- a/components/ui/AddImageField.tsx
+++ b/components/ui/AddImageField.tsx
@@ -15,6 +15,7 @@ import { useEffect, useState } from 'react';
 import {
   Alert,
   LayoutChangeEvent,
+  Linking,
   Modal,
   Platform,
   Pressable,
@@ -86,6 +87,17 @@ function getNewImages(
   const existingIds = new Set(currentImages.map((image) => image.id));
 
   return pickedImages.filter((image) => !existingIds.has(image.id));
+}
+
+async function openAppSettings() {
+  try {
+    await Linking.openSettings();
+  } catch {
+    Alert.alert(
+      'Could not open settings',
+      'Open your device settings to allow photo library access for this app.',
+    );
+  }
 }
 
 export function AddImageField({
@@ -169,6 +181,18 @@ export function AddImageField({
     Alert.alert(
       'Photo access needed',
       'Allow photo library access to add images to this event.',
+      [
+        {
+          text: 'Not now',
+          style: 'cancel',
+        },
+        {
+          text: 'Open settings',
+          onPress: () => {
+            void openAppSettings();
+          },
+        },
+      ],
     );
     return false;
   }

--- a/components/ui/AddImageField.tsx
+++ b/components/ui/AddImageField.tsx
@@ -4,17 +4,26 @@ import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
 import { Image } from 'expo-image';
 import * as ImagePicker from 'expo-image-picker';
-import { Camera, Plus, X } from 'lucide-react-native';
-import { useState } from 'react';
+import {
+  Camera,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  X,
+} from 'lucide-react-native';
+import { useEffect, useState } from 'react';
 import {
   Alert,
   LayoutChangeEvent,
+  Modal,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   View,
   type ViewProps,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Text } from './Text';
 
@@ -40,9 +49,10 @@ export type SelectedImage = {
 
 interface AddImageFieldProps extends ViewProps {
   value: SelectedImage[];
-  onChange: (next: SelectedImage[]) => void;
+  onChange?: (next: SelectedImage[]) => void;
   label?: string;
   color?: string;
+  editable?: boolean;
   allowsMultipleSelection?: boolean;
   maxImages?: number;
   disabled?: boolean;
@@ -83,8 +93,9 @@ export function AddImageField({
   onChange,
   label = 'Photos',
   color = sectionColors.events,
+  editable,
   allowsMultipleSelection = true,
-  maxImages = DEFAULT_MAX_IMAGES,
+  maxImages,
   disabled = false,
   onRequestUpload,
   style,
@@ -92,14 +103,40 @@ export function AddImageField({
 }: AddImageFieldProps) {
   const [isPicking, setIsPicking] = useState(false);
   const [gridWidth, setGridWidth] = useState(0);
-  const images = value.slice(0, maxImages);
-  const remainingSlots = Math.max(maxImages - images.length, 0);
-  const canAddMore = remainingSlots > 0;
-  const isDisabled = disabled || isPicking;
+  const [activeImageIndex, setActiveImageIndex] = useState<number | null>(null);
+  const isEditable = editable ?? Boolean(onChange);
+  const resolvedMaxImages =
+    maxImages ??
+    (isEditable ? DEFAULT_MAX_IMAGES : value.length || DEFAULT_MAX_IMAGES);
+  const images = value.slice(0, resolvedMaxImages);
+  const imageCount = value.length;
+  const remainingSlots = Math.max(resolvedMaxImages - images.length, 0);
+  const canAddMore = isEditable && remainingSlots > 0;
+  const isDisabled = disabled || isPicking || !isEditable;
   const itemSize =
     gridWidth > GRID_GAP * (GRID_COLUMNS - 1)
       ? (gridWidth - GRID_GAP * (GRID_COLUMNS - 1)) / GRID_COLUMNS
       : 0;
+  const activeImage =
+    activeImageIndex === null ? null : images[activeImageIndex];
+  const canGoBackward = activeImageIndex !== null && activeImageIndex > 0;
+  const canGoForward =
+    activeImageIndex !== null && activeImageIndex < images.length - 1;
+
+  useEffect(() => {
+    if (activeImageIndex === null) {
+      return;
+    }
+
+    if (images.length === 0) {
+      setActiveImageIndex(null);
+      return;
+    }
+
+    if (activeImageIndex > images.length - 1) {
+      setActiveImageIndex(images.length - 1);
+    }
+  }, [activeImageIndex, images.length]);
 
   function handleGridLayout(event: LayoutChangeEvent) {
     const nextWidth = Math.round(event.nativeEvent.layout.width);
@@ -137,7 +174,7 @@ export function AddImageField({
   }
 
   async function handleAddImages() {
-    if (isDisabled || !canAddMore) {
+    if (!isEditable || !onChange || isDisabled || !canAddMore) {
       return;
     }
 
@@ -182,14 +219,50 @@ export function AddImageField({
   }
 
   function handleRemoveImage(imageId: string) {
+    if (!isEditable || !onChange || disabled || isPicking) {
+      return;
+    }
+
     onChange(images.filter((image) => image.id !== imageId));
+  }
+
+  function handleOpenViewer(index: number) {
+    if (!images[index]) {
+      return;
+    }
+
+    setActiveImageIndex(index);
+  }
+
+  function handleCloseViewer() {
+    setActiveImageIndex(null);
+  }
+
+  function handlePreviousImage() {
+    setActiveImageIndex((currentIndex) => {
+      if (currentIndex === null || currentIndex === 0) {
+        return currentIndex;
+      }
+
+      return currentIndex - 1;
+    });
+  }
+
+  function handleNextImage() {
+    setActiveImageIndex((currentIndex) => {
+      if (currentIndex === null || currentIndex >= images.length - 1) {
+        return currentIndex;
+      }
+
+      return currentIndex + 1;
+    });
   }
 
   return (
     <View {...rest} style={[styles.field, style]}>
       <View style={styles.header}>
         <Text style={styles.label}>
-          {label} <Text style={styles.count}>({images.length})</Text>
+          {label} <Text style={styles.count}>({imageCount})</Text>
         </Text>
 
         {canAddMore ? (
@@ -214,50 +287,81 @@ export function AddImageField({
       </View>
 
       {images.length === 0 ? (
-        <Pressable
-          accessibilityHint="Opens your photo library"
-          accessibilityLabel={`Add photos to ${label.toLowerCase()}`}
-          accessibilityRole="button"
-          disabled={isDisabled}
-          onPress={handleAddImages}
-          style={({ pressed }) => [
-            styles.emptyTrigger,
-            pressed && !isDisabled ? styles.pressed : null,
-            isDisabled ? styles.disabled : null,
-          ]}
-        >
-          <Camera
-            color={baseColors.textMuted}
-            size={textTheme.size.xl + space.sm}
-            strokeWidth={1.75}
-          />
-          <Text style={styles.emptyText}>Tap to add photos</Text>
-        </Pressable>
+        isEditable ? (
+          <Pressable
+            accessibilityHint="Opens your photo library"
+            accessibilityLabel={`Add photos to ${label.toLowerCase()}`}
+            accessibilityRole="button"
+            disabled={isDisabled}
+            onPress={handleAddImages}
+            style={({ pressed }) => [
+              styles.emptyTrigger,
+              pressed && !isDisabled ? styles.pressed : null,
+              isDisabled ? styles.disabled : null,
+            ]}
+          >
+            <Camera
+              color={baseColors.textMuted}
+              size={textTheme.size.xl + space.sm}
+              strokeWidth={1.75}
+            />
+            <Text style={styles.emptyText}>Tap to add photos</Text>
+          </Pressable>
+        ) : (
+          <View style={[styles.emptyTrigger, styles.emptyState]}>
+            <Camera
+              color={baseColors.textMuted}
+              size={textTheme.size.xl + space.sm}
+              strokeWidth={1.75}
+            />
+            <Text style={styles.emptyText}>No photos yet</Text>
+          </View>
+        )
       ) : (
         <View onLayout={handleGridLayout} style={styles.grid}>
-          {images.map((image) => (
+          {images.map((image, index) => (
             <View
               key={image.id}
-              style={[styles.gridItem, { height: itemSize, width: itemSize }]}
+              style={[
+                styles.gridItemShell,
+                { height: itemSize, width: itemSize },
+              ]}
             >
-              <Image
-                source={{ uri: image.publicUrl ?? image.uri }}
-                style={styles.preview}
-                contentFit="cover"
-              />
               <Pressable
-                accessibilityHint="Removes this photo from the event draft"
-                accessibilityLabel={`Remove ${image.fileName ?? 'photo'}`}
+                accessibilityHint="Opens this photo full screen"
+                accessibilityLabel={`View ${image.fileName ?? 'photo'} full screen`}
                 accessibilityRole="button"
-                hitSlop={space.sm}
-                onPress={() => handleRemoveImage(image.id)}
+                onPress={() => handleOpenViewer(index)}
                 style={({ pressed }) => [
-                  styles.removeButton,
+                  styles.gridItem,
+                  { height: itemSize, width: itemSize },
                   pressed ? styles.pressed : null,
                 ]}
               >
-                <X color={baseColors.text} size={14} strokeWidth={2.25} />
+                <Image
+                  source={{ uri: image.publicUrl ?? image.uri }}
+                  style={styles.preview}
+                  contentFit="cover"
+                />
               </Pressable>
+
+              {isEditable ? (
+                <Pressable
+                  accessibilityHint="Removes this photo from the event draft"
+                  accessibilityLabel={`Remove ${image.fileName ?? 'photo'}`}
+                  accessibilityRole="button"
+                  disabled={disabled || isPicking}
+                  hitSlop={space.sm}
+                  onPress={() => handleRemoveImage(image.id)}
+                  style={({ pressed }) => [
+                    styles.removeButton,
+                    pressed && !disabled && !isPicking ? styles.pressed : null,
+                    disabled || isPicking ? styles.disabled : null,
+                  ]}
+                >
+                  <X color={baseColors.text} size={14} strokeWidth={2.25} />
+                </Pressable>
+              ) : null}
             </View>
           ))}
 
@@ -281,6 +385,128 @@ export function AddImageField({
           ) : null}
         </View>
       )}
+
+      <Modal
+        animationType="fade"
+        onRequestClose={handleCloseViewer}
+        transparent
+        visible={activeImageIndex !== null}
+      >
+        <SafeAreaView edges={['top', 'bottom']} style={styles.viewerSafeArea}>
+          <View style={styles.viewerHeader}>
+            <Pressable
+              accessibilityHint="Closes the photo viewer"
+              accessibilityLabel="Close photo viewer"
+              accessibilityRole="button"
+              hitSlop={space.sm}
+              onPress={handleCloseViewer}
+              style={({ pressed }) => [
+                styles.viewerHeaderButton,
+                pressed ? styles.pressed : null,
+              ]}
+            >
+              <X color={baseColors.text} size={18} strokeWidth={2.25} />
+            </Pressable>
+
+            <Text style={styles.viewerCount}>
+              {activeImageIndex === null
+                ? ''
+                : `${activeImageIndex + 1} of ${images.length}`}
+            </Text>
+
+            <View style={styles.viewerHeaderSpacer} />
+          </View>
+
+          <View style={styles.viewerBody}>
+            {images.length > 1 ? (
+              <Pressable
+                accessibilityHint="Shows the previous photo"
+                accessibilityLabel="Previous photo"
+                accessibilityRole="button"
+                disabled={!canGoBackward}
+                onPress={handlePreviousImage}
+                style={({ pressed }) => [
+                  styles.viewerNavButton,
+                  !canGoBackward ? styles.disabled : null,
+                  pressed && canGoBackward ? styles.pressed : null,
+                ]}
+              >
+                <ChevronLeft
+                  color={baseColors.text}
+                  size={22}
+                  strokeWidth={2.25}
+                />
+              </Pressable>
+            ) : (
+              <View style={styles.viewerNavSpacer} />
+            )}
+
+            <View style={styles.viewerImageFrame}>
+              {activeImage ? (
+                <Image
+                  source={{ uri: activeImage.publicUrl ?? activeImage.uri }}
+                  style={styles.viewerImage}
+                  contentFit="contain"
+                />
+              ) : null}
+            </View>
+
+            {images.length > 1 ? (
+              <Pressable
+                accessibilityHint="Shows the next photo"
+                accessibilityLabel="Next photo"
+                accessibilityRole="button"
+                disabled={!canGoForward}
+                onPress={handleNextImage}
+                style={({ pressed }) => [
+                  styles.viewerNavButton,
+                  !canGoForward ? styles.disabled : null,
+                  pressed && canGoForward ? styles.pressed : null,
+                ]}
+              >
+                <ChevronRight
+                  color={baseColors.text}
+                  size={22}
+                  strokeWidth={2.25}
+                />
+              </Pressable>
+            ) : (
+              <View style={styles.viewerNavSpacer} />
+            )}
+          </View>
+
+          {images.length > 1 ? (
+            <ScrollView
+              contentContainerStyle={styles.viewerThumbnailContent}
+              horizontal
+              showsHorizontalScrollIndicator={false}
+            >
+              {images.map((image, index) => (
+                <Pressable
+                  key={`${image.id}-viewer-thumb`}
+                  accessibilityHint="Shows this photo in the viewer"
+                  accessibilityLabel={`Open photo ${index + 1}`}
+                  accessibilityRole="button"
+                  onPress={() => handleOpenViewer(index)}
+                  style={({ pressed }) => [
+                    styles.viewerThumbnail,
+                    activeImageIndex === index
+                      ? styles.viewerThumbnailActive
+                      : null,
+                    pressed ? styles.pressed : null,
+                  ]}
+                >
+                  <Image
+                    source={{ uri: image.publicUrl ?? image.uri }}
+                    style={styles.viewerThumbnailImage}
+                    contentFit="cover"
+                  />
+                </Pressable>
+              ))}
+            </ScrollView>
+          ) : null}
+        </SafeAreaView>
+      </Modal>
     </View>
   );
 }
@@ -333,10 +559,16 @@ const styles = StyleSheet.create({
     fontSize: textTheme.size.md,
     lineHeight: textTheme.lineHeight.md,
   },
+  emptyState: {
+    borderStyle: 'solid',
+  },
   grid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: space.md,
+  },
+  gridItemShell: {
+    position: 'relative',
   },
   gridItem: {
     backgroundColor: baseColors.card,
@@ -368,6 +600,86 @@ const styles = StyleSheet.create({
     borderStyle: 'dashed',
     borderWidth: 2,
     justifyContent: 'center',
+  },
+  viewerSafeArea: {
+    backgroundColor: 'rgba(15, 13, 12, 0.96)',
+    flex: 1,
+  },
+  viewerHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: space.lg,
+    paddingTop: space.sm,
+  },
+  viewerHeaderButton: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(245, 240, 236, 0.08)',
+    borderColor: 'rgba(245, 240, 236, 0.16)',
+    borderRadius: radius.full,
+    borderWidth: 1,
+    height: 36,
+    justifyContent: 'center',
+    width: 36,
+  },
+  viewerCount: {
+    color: baseColors.text,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.md,
+    lineHeight: textTheme.lineHeight.md,
+  },
+  viewerHeaderSpacer: {
+    width: 36,
+  },
+  viewerBody: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: space.sm,
+    paddingHorizontal: space.md,
+    paddingVertical: space.xl,
+  },
+  viewerImageFrame: {
+    flex: 1,
+    height: '100%',
+    justifyContent: 'center',
+  },
+  viewerImage: {
+    flex: 1,
+    width: '100%',
+  },
+  viewerNavButton: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(245, 240, 236, 0.08)',
+    borderColor: 'rgba(245, 240, 236, 0.16)',
+    borderRadius: radius.full,
+    borderWidth: 1,
+    height: 40,
+    justifyContent: 'center',
+    width: 40,
+  },
+  viewerNavSpacer: {
+    width: 40,
+  },
+  viewerThumbnailContent: {
+    gap: space.sm,
+    paddingHorizontal: space.lg,
+    paddingBottom: space.lg,
+  },
+  viewerThumbnail: {
+    borderColor: 'transparent',
+    borderRadius: radius.md,
+    borderWidth: 2,
+    height: 64,
+    overflow: 'hidden',
+    width: 64,
+  },
+  viewerThumbnailActive: {
+    borderColor: baseColors.text,
+  },
+  viewerThumbnailImage: {
+    height: '100%',
+    width: '100%',
   },
   pressed: {
     opacity: 0.82,

--- a/components/ui/AddImageField.tsx
+++ b/components/ui/AddImageField.tsx
@@ -33,6 +33,7 @@ export type ImageUploadStatus = 'local' | 'uploading' | 'uploaded' | 'failed';
 const DEFAULT_MAX_IMAGES = 6;
 const GRID_COLUMNS = 3;
 const GRID_GAP = space.md;
+const APP_NAME = 'Memoir';
 
 export type SelectedImage = {
   id: string;
@@ -93,11 +94,20 @@ async function openAppSettings() {
   try {
     await Linking.openSettings();
   } catch {
-    Alert.alert(
-      'Could not open settings',
-      'Open your device settings to allow photo library access for this app.',
-    );
+    Alert.alert('Could not open settings', getPhotoAccessInstructions());
   }
+}
+
+function getPhotoAccessInstructions() {
+  if (Platform.OS === 'ios') {
+    return `Open Settings > ${APP_NAME} > Photos, then choose Full Access or Limited Access.`;
+  }
+
+  if (Platform.OS === 'android') {
+    return `Open Settings > Apps > ${APP_NAME} > Permissions > Photos and videos, then tap Allow.`;
+  }
+
+  return 'Open your device settings and allow photo library access for this app.';
 }
 
 export function AddImageField({
@@ -180,14 +190,14 @@ export function AddImageField({
 
     Alert.alert(
       'Photo access needed',
-      'Allow photo library access to add images to this event.',
+      `Allow photo library access to add images to this event.\n\n${getPhotoAccessInstructions()}`,
       [
         {
           text: 'Not now',
           style: 'cancel',
         },
         {
-          text: 'Open settings',
+          text: 'Open app settings',
           onPress: () => {
             void openAppSettings();
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-image-picker": "~17.0.10",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
         "expo-splash-screen": "~31.0.13",
@@ -6557,6 +6558,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.10.tgz",
+      "integrity": "sha512-a2xrowp2trmvXyUWgX3O6Q2rZaa2C59AqivKI7+bm+wLvMfTEbZgldLX4rEJJhM8xtmEDTNU+lzjtObwzBRGaw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-image-picker": "~17.0.10",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-splash-screen": "~31.0.13",


### PR DESCRIPTION
## Summary
This PR adds a reusable photo picker field for event forms, extends it into a reusable full-screen image viewer for future `[id]` detail pages, and fixes the two integration issues found while testing in Expo Go:

- image selection could get stuck behind a denied media-library permission flow in Expo Go
- full-screen viewer controls rendered too close to the status bar on device

## What changed
- added a shared `AddImageField` component that:
  - opens the system image library
  - supports multi-select with duplicate filtering
  - renders an empty state and thumbnail grid
  - supports removal in editable contexts
  - can also run in read-only mode for detail pages
- wired the new field into the new event screen so drafts can collect photos alongside title, date, and description
- added a built-in full-screen modal viewer with:
  - tap-to-open thumbnails
  - previous / next navigation
  - thumbnail strip navigation
  - reusable read-only behavior for future entity detail screens
- removed the preflight media-library permission gate from the picker flow so Expo Go can open the image library directly instead of trapping the user in a dead-end denied state
- wrapped the app with `SafeAreaProvider` and offset the viewer header with the real top inset so close/navigation controls render below the status bar
- added the `expo-image-picker` dependency required for the shared picker flow

## Why
The feature work started as a new-event photo attachment field, but the UI needs to be shared across create flows and future `[id]` detail pages. Turning the picker into a reusable gallery/viewer component keeps the interaction model consistent everywhere we show attached images.

During testing, Expo Go exposed a practical issue with the original permission strategy: manually requesting media-library access before opening the picker could leave the user stuck once that permission path was denied. The current approach relies on the system picker directly for normal image selection, which is a better fit for Expo Go testing and the current implementation.

## User impact
- users can attach several photos while creating an event
- users can tap any attached image to inspect it full screen
- future detail pages can reuse the same component without re-implementing gallery behavior
- full-screen viewer controls are positioned safely below the status bar
- Expo Go testing no longer depends on recovering from a dead-end permission prompt before opening the library

## Validation
- `npm run lint`
- `npx tsc --noEmit`
