### PR TITLE
Memories page

### DIFF
--- a/app/(tabs)/memories.tsx
+++ b/app/(tabs)/memories.tsx
@@ -1,31 +1,98 @@
-import { StyleSheet, Text, View } from 'react-native';
+import Image from '@/components/ui/Image';
+import { baseColors, sectionColors } from '@/theme/colors';
+import { space } from '@/theme/space';
+import { text } from '@/theme/type';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 
+const ITEM_WIDTH = 175;
+const COLUMNS = 2;
 export default function MemoriesScreen() {
+  const memories = [
+    {
+      id: 1,
+      title: 'Beach Vacation',
+      date: 'June 2023',
+      imageUrl:
+        'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80',
+    },
+    {
+      id: 2,
+      title: 'Mountain Hike',
+      date: 'September 2023',
+      imageUrl:
+        'https://images.unsplash.com/photo-1500534623283-312aade485b7?auto=format&fit=crop&w=800&q=80',
+    },
+    {
+      id: 3,
+      title: 'City Exploration',
+      date: 'December 2023',
+      imageUrl:
+        'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=800&q=80',
+    },
+  ];
+
+  const { width } = useWindowDimensions();
+  const horizontalPadding = space.lg * 2; // same as your container paddingHorizontal
+  const availableWidth = width - horizontalPadding;
+  const gap = (availableWidth - ITEM_WIDTH * COLUMNS) / (COLUMNS - 1);
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Memories</Text>
-      <Text style={styles.text}>Scaffold page for memory collections.</Text>
-    </View>
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+    >
+      <View style={styles.container}>
+        <Text style={styles.title}>✦ {memories.length} memories ✦</Text>
+        <View
+          style={[
+            styles.memoriesContainer,
+            { flexDirection: 'row', alignItems: 'center', gap: gap },
+          ]}
+        >
+          {memories.map((memory) => (
+            <Image
+              key={memory.id}
+              source={memory.imageUrl}
+              variant="polaroid"
+              polaroid={{ color: '#2fe', date: memory.date }}
+            />
+          ))}
+        </View>
+      </View>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: baseColors.bg,
+  },
+  content: {
+    paddingHorizontal: space.lg,
+    paddingTop: space.xl,
+  },
   container: {
     flex: 1,
-    backgroundColor: '#1a1a1a',
+    backgroundColor: baseColors.bg,
     justifyContent: 'center',
     alignItems: 'center',
-    padding: 24,
+    gap: space.md,
   },
   title: {
-    color: '#f5f0ec',
-    fontSize: 28,
-    fontWeight: '700',
+    color: sectionColors.memories,
+    fontSize: text.size.xl,
+    fontFamily: text.family.semiBold,
     marginBottom: 10,
   },
-  text: {
-    color: '#b8b0a8',
-    fontSize: 16,
-    textAlign: 'center',
+  memoriesContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
   },
 });

--- a/app/(tabs)/memories.tsx
+++ b/app/(tabs)/memories.tsx
@@ -1,9 +1,14 @@
+import Button from '@/components/ui/Button';
 import Image from '@/components/ui/Image';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
 import { text } from '@/theme/type';
-import { Link } from 'expo-router';
+import { Image as ExpoImage } from 'expo-image';
+import { navigate } from 'expo-router/build/global-state/routing';
+import { useState } from 'react';
 import {
+  Modal as ExpoModal,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -13,14 +18,31 @@ import {
 
 const ITEM_WIDTH = 175;
 const COLUMNS = 2;
+
+type MemoryType = 'moment' | 'event' | 'chapter';
+
+interface MemoryItem {
+  id: number;
+  title: string;
+  date: string;
+  imageUrl: string;
+  type: MemoryType;
+}
+
+const MEMORY_TYPE_COLORS: Record<MemoryType, string> = {
+  moment: sectionColors.moments,
+  event: sectionColors.events,
+  chapter: sectionColors.chapters,
+};
 export default function MemoriesScreen() {
-  const memories = [
+  const memories: MemoryItem[] = [
     {
       id: 1,
       title: 'Beach Vacation',
       date: 'June 2023',
       imageUrl:
         'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80',
+      type: 'moment',
     },
     {
       id: 2,
@@ -28,6 +50,7 @@ export default function MemoriesScreen() {
       date: 'September 2023',
       imageUrl:
         'https://images.unsplash.com/photo-1500534623283-312aade485b7?auto=format&fit=crop&w=800&q=80',
+      type: 'event',
     },
     {
       id: 3,
@@ -35,6 +58,55 @@ export default function MemoriesScreen() {
       date: 'December 2023',
       imageUrl:
         'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=800&q=80',
+      type: 'chapter',
+    },
+    {
+      id: 4,
+      title: 'Forest Camping',
+      date: 'April 2024',
+      imageUrl:
+        'https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=800&q=80',
+      type: 'moment',
+    },
+    {
+      id: 5,
+      title: 'Desert Road Trip',
+      date: 'August 2023',
+      imageUrl:
+        'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=80',
+      type: 'event',
+    },
+    {
+      id: 6,
+      title: 'Snowy Getaway',
+      date: 'January 2024',
+      imageUrl:
+        'https://images.unsplash.com/photo-1519608487953-e999c86e7455?auto=format&fit=crop&w=800&q=80',
+      type: 'chapter',
+    },
+    {
+      id: 7,
+      title: 'Lakeside Retreat',
+      date: 'May 2024',
+      imageUrl:
+        'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80',
+      type: 'moment',
+    },
+    {
+      id: 8,
+      title: 'Countryside Picnic',
+      date: 'July 2023',
+      imageUrl:
+        'https://images.unsplash.com/photo-1500534623283-312aade485b7?auto=format&fit=crop&w=800&q=80',
+      type: 'event',
+    },
+    {
+      id: 9,
+      title: 'Urban Art Tour',
+      date: 'November 2023',
+      imageUrl:
+        'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=800&q=80',
+      type: 'chapter',
     },
   ];
 
@@ -42,12 +114,19 @@ export default function MemoriesScreen() {
   const horizontalPadding = space.lg * 2; // same as your container paddingHorizontal
   const availableWidth = width - horizontalPadding - 1; // subtracting 1 to account for rounding issues
   const gap = (availableWidth - ITEM_WIDTH * COLUMNS) / (COLUMNS - 1);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [selectedMemory, setSelectedMemory] = useState<MemoryItem | null>(null);
   return (
     <ScrollView
-      style={styles.screen}
       contentContainerStyle={styles.content}
       showsVerticalScrollIndicator={false}
     >
+      <Modal
+        modalVisible={modalVisible}
+        setModalVisible={setModalVisible}
+        selectedMemory={selectedMemory}
+      />
+
       <View style={styles.container}>
         <Text style={styles.title}>✦ {memories.length} memories ✦</Text>
         <View
@@ -57,13 +136,22 @@ export default function MemoriesScreen() {
           ]}
         >
           {memories.map((memory) => (
-            <Link key={memory.id} href={`/`}>
+            <Pressable
+              key={memory.id}
+              onPress={() => {
+                setSelectedMemory(memory);
+                setModalVisible(true);
+              }}
+            >
               <Image
                 source={memory.imageUrl}
                 variant="polaroid"
-                polaroid={{ color: '#2fe', date: memory.date }}
+                polaroid={{
+                  color: MEMORY_TYPE_COLORS[memory.type],
+                  date: memory.date,
+                }}
               />
-            </Link>
+            </Pressable>
           ))}
         </View>
       </View>
@@ -71,11 +159,70 @@ export default function MemoriesScreen() {
   );
 }
 
+function Modal({
+  modalVisible,
+  setModalVisible,
+  selectedMemory,
+}: {
+  modalVisible: boolean;
+  setModalVisible: (visible: boolean) => void;
+  selectedMemory: MemoryItem | null;
+}) {
+  return (
+    <ExpoModal
+      animationType="fade"
+      transparent={true}
+      visible={modalVisible}
+      onRequestClose={() => {
+        setModalVisible(!modalVisible);
+      }}
+    >
+      <Pressable
+        style={styles.centeredView}
+        onPress={() => setModalVisible(false)}
+      >
+        <Pressable
+          style={[styles.modalView]}
+          onPress={(event) => event.stopPropagation()}
+        >
+          <ExpoImage
+            source={{
+              uri:
+                selectedMemory?.imageUrl ||
+                'https://via.placeholder.com/600x400',
+            }}
+            style={[styles.modalImage]}
+          />
+          <View style={{ alignItems: 'center', gap: space.xxs }}>
+            <Text style={styles.modalTextTitle}>{selectedMemory?.title}</Text>
+            <Text style={styles.modalTextDate}>
+              {selectedMemory?.date || 'Unknown Date'}
+            </Text>
+          </View>
+          <Button
+            color={
+              MEMORY_TYPE_COLORS[
+                (selectedMemory?.type as MemoryType) || 'moments'
+              ]
+            }
+            variant="default"
+            label={`See ${selectedMemory?.type as MemoryType}`}
+            onPress={() => {
+              navigate(`/${selectedMemory?.type as MemoryType}s#${selectedMemory?.id}`);
+              setModalVisible(false);
+            }}
+            // Handle see memory action, e.g., navigate to detail screen
+          />
+        </Pressable>
+        <View>
+          <Text style={styles.closeButton}>Click anywhere to close</Text>
+        </View>
+      </Pressable>
+    </ExpoModal>
+  );
+}
+
 const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: baseColors.bg,
-  },
   content: {
     paddingHorizontal: space.lg,
     paddingTop: space.xl,
@@ -96,5 +243,58 @@ const styles = StyleSheet.create({
   memoriesContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',
+  },
+
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 12,
+    backgroundColor: 'rgba(0, 0, 0, 0.65)',
+  },
+
+  modalView: {
+    maxWidth: 360,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    height: 'auto',
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+    width: '100%',
+    backgroundColor: baseColors.text,
+    padding: 25,
+    position: 'relative',
+    borderRadius: 4,
+    alignItems: 'center',
+    gap: space.sm,
+  },
+
+  modalImage: {
+    width: '100%',
+    aspectRatio: 1 / 1,
+    objectFit: 'cover',
+    borderRadius: 2,
+  },
+
+  modalTextTitle: {
+    fontFamily: text.family.semiBold,
+    lineHeight: text.lineHeight.xl,
+    fontSize: text.size.xl,
+  },
+  modalTextDate: {
+    fontSize: text.size.xs,
+    lineHeight: text.lineHeight.xs,
+    fontFamily: text.family.mediumItalic,
+  },
+
+  closeButton: {
+    fontSize: text.size.xs,
+    lineHeight: text.lineHeight.xs,
+    fontFamily: text.family.mediumItalic,
+    color: baseColors.textSoft,
   },
 });

--- a/app/(tabs)/memories.tsx
+++ b/app/(tabs)/memories.tsx
@@ -2,6 +2,7 @@ import Image from '@/components/ui/Image';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
 import { text } from '@/theme/type';
+import { Link } from 'expo-router';
 import {
   ScrollView,
   StyleSheet,
@@ -39,7 +40,7 @@ export default function MemoriesScreen() {
 
   const { width } = useWindowDimensions();
   const horizontalPadding = space.lg * 2; // same as your container paddingHorizontal
-  const availableWidth = width - horizontalPadding;
+  const availableWidth = width - horizontalPadding - 1; // subtracting 1 to account for rounding issues
   const gap = (availableWidth - ITEM_WIDTH * COLUMNS) / (COLUMNS - 1);
   return (
     <ScrollView
@@ -56,12 +57,13 @@ export default function MemoriesScreen() {
           ]}
         >
           {memories.map((memory) => (
-            <Image
-              key={memory.id}
-              source={memory.imageUrl}
-              variant="polaroid"
-              polaroid={{ color: '#2fe', date: memory.date }}
-            />
+            <Link key={memory.id} href={`/`}>
+              <Image
+                source={memory.imageUrl}
+                variant="polaroid"
+                polaroid={{ color: '#2fe', date: memory.date }}
+              />
+            </Link>
           ))}
         </View>
       </View>

--- a/lib/supabase.web.ts
+++ b/lib/supabase.web.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js';
+import 'react-native-url-polyfill/auto';
+
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const supabasePublishableKey = process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('Missing env variable: EXPO_PUBLIC_SUPABASE_URL');
+}
+if (!supabasePublishableKey) {
+  throw new Error('Missing env variable: EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY');
+}
+
+export const supabase = createClient(supabaseUrl!, supabasePublishableKey!, {
+  auth: {
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false,
+  },
+});


### PR DESCRIPTION
This pull request introduces a new, visually rich "Memories" screen and adds initial Supabase client configuration for web support. The main focus is on implementing a user-friendly, interactive grid of memory items with modal detail views, and setting up the groundwork for backend integration.

**Memories screen UI and functionality:**

* Implements a new `MemoriesScreen` in `memories.tsx`, featuring a 2-column grid of memory items, each with an image, title, date, and type-specific styling. Tapping a memory opens a modal with more details and a navigation button to the relevant memory type.
* Adds a custom modal component for displaying memory details, including image, title, date, and a contextual action button.
* Refactors styling to use shared theme variables for color, spacing, and typography, ensuring consistency with the app's design system.

**Supabase integration setup:**

* Adds a new `supabase.web.ts` file that initializes the Supabase client using environment variables, with error handling for missing configuration. This sets up the foundation for future backend data fetching and authentication.