### PR TITLE
Add events CRUD flow

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -82,10 +82,16 @@ export default function TabLayout() {
       />
       <Tabs.Screen
         name="events"
-        options={{
-          title: 'Events',
-          tabBarActiveTintColor: sectionColors.events,
-          tabBarIcon: ({ color }) => <CalendarDays color={color} size={24} />,
+        options={({ route }) => {
+          const focusedRouteName =
+            getFocusedRouteNameFromRoute(route) ?? 'index';
+
+          return {
+            title: 'Events',
+            headerShown: focusedRouteName !== '[id]',
+            tabBarActiveTintColor: sectionColors.events,
+            tabBarIcon: ({ color }) => <CalendarDays color={color} size={24} />,
+          };
         }}
       />
       <Tabs.Screen

--- a/app/(tabs)/events/[id].tsx
+++ b/app/(tabs)/events/[id].tsx
@@ -1,56 +1,352 @@
+import Divider from '@/components/ui/Divider';
 import { Text } from '@/components/ui/Text';
+import { eventKeys, getEventById } from '@/lib/events';
 import { baseColors, sectionColors } from '@/theme/colors';
+import { radius } from '@/theme/radius';
 import { space } from '@/theme/space';
-import { text } from '@/theme/type';
-import { Link } from 'expo-router';
-import { StyleSheet, View } from 'react-native';
+import { text as textTheme } from '@/theme/type';
+import { useQuery } from '@tanstack/react-query';
+import { Image } from 'expo-image';
+import { router, useLocalSearchParams } from 'expo-router';
+import { CalendarDays, ChevronLeft, MapPin } from 'lucide-react-native';
+import { useMemo } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const FALLBACK_COVER_IMAGE = require('../../../assets/images/fallbackImage.png');
+
+function formatOccurredOn(dateValue: string): string {
+  const date = new Date(dateValue);
+
+  if (Number.isNaN(date.getTime())) {
+    return dateValue;
+  }
+
+  return date.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
 
 export default function EventDetailScreen() {
-  return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Event Detail</Text>
-      <Text style={styles.text}>Scaffold page for a single event.</Text>
-      <View style={styles.links}>
-        <Link href="/events" style={styles.link}>
-          Back to events
-        </Link>
-        <Link href="/events/new" style={styles.link}>
-          Go to new event
-        </Link>
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{ id?: string | string[] }>();
+  const rawId = params.id;
+  const eventId = Array.isArray(rawId) ? rawId[0] : rawId;
+  const eventQuery = useQuery({
+    queryKey: eventKeys.detail(eventId ?? 'missing'),
+    queryFn: () => getEventById(eventId!),
+    enabled: Boolean(eventId),
+  });
+
+  const displayDate = useMemo(
+    () =>
+      eventQuery.data?.occurredOn
+        ? formatOccurredOn(eventQuery.data.occurredOn)
+        : '',
+    [eventQuery.data?.occurredOn],
+  );
+  const heroImageSource = eventQuery.data?.photos[0]
+    ? { uri: eventQuery.data.photos[0] }
+    : FALLBACK_COVER_IMAGE;
+  const photoThumbs = eventQuery.data?.photos.slice(0, 3) ?? [];
+  const loadError =
+    eventQuery.error instanceof Error
+      ? eventQuery.error.message
+      : eventQuery.error
+        ? 'Could not load event.'
+        : null;
+  const hasNotes = Boolean(eventQuery.data?.notes?.trim());
+
+  if (eventQuery.isPending) {
+    return (
+      <View style={styles.screenCentered}>
+        <ActivityIndicator color={sectionColors.events} />
       </View>
+    );
+  }
+
+  if (!eventId || loadError || !eventQuery.data) {
+    return (
+      <View style={styles.screenCentered}>
+        <Text style={styles.errorText}>{loadError ?? 'Event not found.'}</Text>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => router.back()}
+          style={styles.backTextButton}
+        >
+          <Text style={styles.backText}>Go back</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.screen}>
+      <ScrollView bounces={false} showsVerticalScrollIndicator={false}>
+        <View style={styles.heroWrap}>
+          <Image
+            contentFit="cover"
+            source={heroImageSource}
+            style={styles.heroImage}
+          />
+          <View style={styles.heroOverlay} />
+
+          <Pressable
+            accessibilityHint="Returns to the events list"
+            accessibilityLabel="Go back"
+            accessibilityRole="button"
+            onPress={() => router.back()}
+            style={[
+              styles.backButton,
+              {
+                top: insets.top + space.sm,
+              },
+            ]}
+          >
+            <ChevronLeft color={baseColors.text} size={22} />
+          </Pressable>
+
+          {eventQuery.data.mood ? (
+            <View style={styles.moodPill}>
+              <Text style={styles.moodPillText}>{eventQuery.data.mood}</Text>
+            </View>
+          ) : null}
+        </View>
+
+        <View style={styles.bodyCard}>
+          <Text style={styles.title}>{eventQuery.data.title}</Text>
+
+          <View style={styles.metaStack}>
+            <View style={styles.metaRow}>
+              <CalendarDays color={sectionColors.events} size={14} />
+              <Text style={styles.dateText}>{displayDate}</Text>
+            </View>
+
+            {eventQuery.data.locationText ? (
+              <View style={styles.metaRow}>
+                <MapPin color={baseColors.textSoft} size={14} />
+                <Text style={styles.locationText}>
+                  {eventQuery.data.locationText}
+                </Text>
+              </View>
+            ) : null}
+          </View>
+
+          <Divider color={sectionColors.events} />
+
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>Mood</Text>
+            <Text style={styles.sectionBody}>
+              {eventQuery.data.mood ?? 'No mood added'}
+            </Text>
+          </View>
+
+          {hasNotes ? (
+            <>
+              <Divider color={sectionColors.events} />
+
+              <View style={styles.section}>
+                <Text style={styles.sectionLabel}>Notes</Text>
+                <Text style={styles.sectionBody}>{eventQuery.data.notes}</Text>
+              </View>
+            </>
+          ) : null}
+
+          <Divider color={sectionColors.events} />
+
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>Photos</Text>
+            <View style={styles.photosRow}>
+              {Array.from({ length: 3 }).map((_, index) => {
+                const photo = photoThumbs[index];
+
+                if (!photo) {
+                  return (
+                    <View
+                      key={`placeholder-${index}`}
+                      style={styles.photoPlaceholder}
+                    >
+                      <Text style={styles.photoPlaceholderText}>+</Text>
+                    </View>
+                  );
+                }
+
+                return (
+                  <View key={photo} style={styles.photoThumbWrap}>
+                    <Image
+                      contentFit="cover"
+                      source={{ uri: photo }}
+                      style={styles.photoThumb}
+                    />
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+        </View>
+      </ScrollView>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  screen: {
     flex: 1,
     backgroundColor: baseColors.bg,
-    justifyContent: 'center',
+  },
+  screenCentered: {
+    flex: 1,
+    backgroundColor: baseColors.bg,
     alignItems: 'center',
-    padding: 24,
+    justifyContent: 'center',
+    paddingHorizontal: space.xl,
+  },
+  heroWrap: {
+    height: 320,
+    position: 'relative',
+  },
+  heroImage: {
+    height: 320,
+    width: '100%',
+  },
+  heroOverlay: {
+    backgroundColor: 'rgba(0, 0, 0, 0.22)',
+    ...StyleSheet.absoluteFillObject,
+  },
+  backButton: {
+    position: 'absolute',
+    left: space.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 40,
+    height: 40,
+    borderRadius: radius.full,
+    backgroundColor: 'rgba(0, 0, 0, 0.45)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.15)',
+  },
+  moodPill: {
+    position: 'absolute',
+    left: space.lg,
+    bottom: space.xl,
+    backgroundColor: sectionColors.events,
+    borderRadius: radius.full,
+    paddingHorizontal: 14,
+    paddingVertical: space.sm,
+  },
+  moodPillText: {
+    color: '#1a1512',
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  bodyCard: {
+    backgroundColor: baseColors.bg,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    marginTop: -20,
+    paddingHorizontal: space.lg,
+    paddingTop: space.xl,
+    paddingBottom: space.xxl,
+    gap: 18,
   },
   title: {
-    color: sectionColors.events,
-    fontSize: text.size.xl,
-    lineHeight: text.lineHeight.xl,
-    marginBottom: space.md,
+    color: baseColors.text,
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.xxl,
+    lineHeight: textTheme.lineHeight.xl,
   },
-  text: {
-    color: baseColors.textSoft,
-    fontSize: 16,
-    textAlign: 'center',
-    marginTop: 4,
+  metaStack: {
+    gap: 6,
   },
-  links: {
-    marginTop: space.xl,
+  metaRow: {
     alignItems: 'center',
+    flexDirection: 'row',
+    gap: space.sm,
   },
-  link: {
+  dateText: {
     color: sectionColors.events,
-    fontFamily: text.family.semiBold,
-    fontSize: text.size.md,
-    marginTop: space.md,
-    textDecorationLine: 'underline',
+    fontFamily: textTheme.family.mediumItalic,
+    fontSize: textTheme.size.xs,
+    lineHeight: textTheme.lineHeight.xs,
+  },
+  locationText: {
+    color: baseColors.textSoft,
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  section: {
+    gap: space.sm,
+  },
+  sectionLabel: {
+    color: baseColors.textSoft,
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+    letterSpacing: 0.78,
+    textTransform: 'uppercase',
+  },
+  sectionBody: {
+    color: baseColors.text,
+    fontFamily: textTheme.family.regular,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  photosRow: {
+    flexDirection: 'row',
+    gap: space.sm,
+  },
+  photoThumbWrap: {
+    width: 111,
+    height: 111,
+    borderRadius: 14,
+    overflow: 'hidden',
+    backgroundColor: baseColors.card,
+  },
+  photoThumb: {
+    width: '100%',
+    height: '100%',
+  },
+  photoPlaceholder: {
+    width: 111,
+    height: 111,
+    borderRadius: 14,
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderColor: 'rgba(107, 101, 96, 0.27)',
+    backgroundColor: baseColors.card,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  photoPlaceholderText: {
+    color: baseColors.textMuted,
+    fontFamily: textTheme.family.regular,
+    fontSize: textTheme.size.sm,
+    lineHeight: 33,
+  },
+  errorText: {
+    color: baseColors.textError,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+    textAlign: 'center',
+  },
+  backTextButton: {
+    marginTop: space.lg,
+  },
+  backText: {
+    color: sectionColors.events,
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
   },
 });

--- a/app/(tabs)/events/_layout.tsx
+++ b/app/(tabs)/events/_layout.tsx
@@ -22,8 +22,7 @@ export default function EventsLayout() {
       <Stack.Screen
         name="[id]"
         options={{
-          headerTitle: '',
-          headerBackButtonDisplayMode: 'minimal',
+          headerShown: false,
         }}
       />
     </Stack>

--- a/app/(tabs)/events/index.tsx
+++ b/app/(tabs)/events/index.tsx
@@ -1,24 +1,106 @@
+import { Card } from '@/components/ui/Card';
 import { Text } from '@/components/ui/Text';
+import { listEventsForCurrentUser, eventKeys } from '@/lib/events';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
 import { text } from '@/theme/type';
-import { Link } from 'expo-router';
-import { StyleSheet, View } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+import { type Href, Link } from 'expo-router';
+import { Plus } from 'lucide-react-native';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+const FALLBACK_COVER_IMAGE = require('@/assets/images/fallbackImage.png');
+
+function formatOccurredOn(dateValue: string): string {
+  const date = new Date(dateValue);
+
+  if (Number.isNaN(date.getTime())) {
+    return dateValue;
+  }
+
+  return date.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
 
 export default function EventsIndexScreen() {
+  const eventsQuery = useQuery({
+    queryKey: eventKeys.list(),
+    queryFn: listEventsForCurrentUser,
+  });
+
+  const events = eventsQuery.data ?? [];
+  const loadError =
+    eventsQuery.error instanceof Error
+      ? eventsQuery.error.message
+      : eventsQuery.error
+        ? 'Failed to load events.'
+        : null;
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Events</Text>
-      <Text style={styles.text}>Scaffold page for the events index.</Text>
-      <View style={styles.links}>
-        <Link href="/events/new" style={styles.link}>
-          Go to new event
-        </Link>
-        <Link href="/events/sample-event" style={styles.link}>
-          Open sample event
-        </Link>
-      </View>
-    </View>
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+      >
+        {eventsQuery.isPending ? (
+          <ActivityIndicator
+            color={sectionColors.events}
+            style={styles.loader}
+          />
+        ) : null}
+
+        {!eventsQuery.isPending && loadError ? (
+          <Text style={styles.errorText}>{loadError}</Text>
+        ) : null}
+
+        {!eventsQuery.isPending && !loadError && events.length === 0 ? (
+          <Text style={styles.emptyText}>
+            No events yet. Tap + to create your first one.
+          </Text>
+        ) : null}
+
+        {!eventsQuery.isPending && !loadError
+          ? events.map((event) => (
+              <Link asChild href={`/events/${event.id}` as Href} key={event.id}>
+                <Pressable
+                  accessibilityHint="Opens this event"
+                  accessibilityRole="button"
+                  style={({ pressed }) => [
+                    styles.cardPressable,
+                    pressed ? styles.cardPressed : null,
+                  ]}
+                >
+                  <Card
+                    color={sectionColors.events}
+                    coverImage={event.coverImage ?? FALLBACK_COVER_IMAGE}
+                    date={formatOccurredOn(event.occurredOn)}
+                    location={event.locationText ?? 'No location added'}
+                    title={event.title}
+                    type={event.mood ?? 'No mood set'}
+                    variant="compressed"
+                  />
+                </Pressable>
+              </Link>
+            ))
+          : null}
+      </ScrollView>
+
+      <Link href="/events/new" asChild>
+        <Pressable accessibilityRole="button" style={styles.createButton}>
+          <Plus color={baseColors.bg} size={28} strokeWidth={2.4} />
+        </Pressable>
+      </Link>
+    </SafeAreaView>
   );
 }
 
@@ -26,28 +108,51 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: baseColors.bg,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
-  title: {
-    color: sectionColors.events,
-    fontSize: text.size.xl,
-    lineHeight: text.lineHeight.xl,
-    marginBottom: space.md,
+  content: {
+    gap: space.md + space.xs,
+    paddingHorizontal: space.lg,
+    paddingBottom: 110,
   },
-  text: {
-    color: baseColors.textMuted,
+  loader: {
+    marginTop: space.xl,
+  },
+  cardPressable: {
+    borderRadius: 26,
+  },
+  cardPressed: {
+    opacity: 0.92,
+  },
+  emptyText: {
+    color: baseColors.textSoft,
+    fontFamily: text.family.regular,
+    fontSize: text.size.md,
+    lineHeight: text.lineHeight.md,
+    marginTop: space.xl,
     textAlign: 'center',
   },
-  links: {
+  errorText: {
+    color: baseColors.textError,
+    fontFamily: text.family.medium,
+    fontSize: text.size.sm,
+    lineHeight: text.lineHeight.sm,
     marginTop: space.xl,
-    alignItems: 'center',
+    textAlign: 'center',
   },
-  link: {
-    color: sectionColors.events,
-    fontFamily: text.family.semiBold,
-    fontSize: text.size.md,
-    marginTop: space.md,
-    textDecorationLine: 'underline',
+  createButton: {
+    alignItems: 'center',
+    backgroundColor: sectionColors.events,
+    borderRadius: 999,
+    bottom: 96,
+    height: 60,
+    width: 60,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: space.xl,
+    shadowColor: baseColors.shadow,
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 1,
+    shadowRadius: 18,
+    elevation: 4,
   },
 });

--- a/app/(tabs)/events/new.tsx
+++ b/app/(tabs)/events/new.tsx
@@ -1,29 +1,36 @@
-import { useState } from 'react';
-
+import { DatePicker } from '@/components/DatePicker';
 import ModalTopBar from '@/components/ModalTopBar';
 import {
   AddImageField,
   type SelectedImage,
 } from '@/components/ui/AddImageField';
 import Chip from '@/components/ui/Chip';
-import { DatePicker } from '@/components/DatePicker';
+import Divider from '@/components/ui/Divider';
 import { Field, Input } from '@/components/ui/Input';
 import { Text } from '@/components/ui/Text';
+import { createEvent, eventKeys } from '@/lib/events';
+import {
+  createEventSchema,
+  type CreateEventValues,
+} from '@/lib/validation/event';
 import { baseColors, sectionColors } from '@/theme/colors';
-import { radius } from '@/theme/radius';
 import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
+import { useForm } from '@tanstack/react-form';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
-import { ChevronDown } from 'lucide-react-native';
-import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
-const EVENT_TYPE_OPTIONS = [
-  'Date night',
-  'Anniversary',
-  'Adventure',
-  'Celebration',
-] as const;
-
+const SAVE_TIMEOUT_MS = 10000;
 const MOOD_OPTIONS = [
   'Magical',
   'Romantic',
@@ -33,203 +40,252 @@ const MOOD_OPTIONS = [
   'Dreamy',
 ] as const;
 
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error('Failed to save event. Please try again.'));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
+}
+
 export default function NewEventScreen() {
-  const [eventType, setEventType] = useState<string | null>(null);
-  const [isEventTypeOpen, setIsEventTypeOpen] = useState(false);
-  const [title, setTitle] = useState('');
-  const [eventDate, setEventDate] = useState(new Date(2026, 3, 14));
-  const [location, setLocation] = useState('');
-  const [mood, setMood] = useState<string>('Romantic');
-  const [description, setDescription] = useState('');
+  const queryClient = useQueryClient();
   const [photos, setPhotos] = useState<SelectedImage[]>([]);
+  const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const createEventMutation = useMutation({
+    mutationFn: createEvent,
+  });
+
+  const form = useForm({
+    defaultValues: {
+      title: '',
+      occurredAt: new Date(),
+      location: '',
+      mood: 'Romantic',
+      notes: '',
+    } satisfies CreateEventValues,
+    onSubmit: async ({ value }) => {
+      const parsed = createEventSchema.safeParse(value);
+
+      if (!parsed.success) {
+        throw new Error(parsed.error.issues[0]?.message ?? 'Invalid input.');
+      }
+
+      try {
+        await createEventMutation.mutateAsync({
+          ...parsed.data,
+          photos,
+        });
+      } catch (error) {
+        if (error instanceof Error) {
+          throw error;
+        }
+
+        throw new Error('Failed to save event. Please try again.');
+      }
+
+      void queryClient.invalidateQueries({
+        queryKey: eventKeys.all,
+      });
+      router.back();
+    },
+  });
+
+  const validation = useMemo(
+    () => createEventSchema.safeParse(form.state.values),
+    [form.state.values],
+  );
+  const fieldErrors = validation.success
+    ? {}
+    : validation.error.flatten().fieldErrors;
+  const submitError = saveError ?? form.state.errorMap.onSubmit;
+
+  const handleSave = async () => {
+    if (isSaving) {
+      return;
+    }
+
+    setHasTriedSubmit(true);
+    setSaveError(null);
+    const parsed = createEventSchema.safeParse(form.state.values);
+
+    if (!parsed.success) {
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      await withTimeout(form.handleSubmit(), SAVE_TIMEOUT_MS);
+    } catch (error) {
+      if (error instanceof Error) {
+        setSaveError(error.message);
+      } else {
+        setSaveError('Failed to save event. Please try again.');
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
   return (
-    <View style={styles.container}>
-      <ModalTopBar
-        color={sectionColors.events}
-        onClose={() => router.back()}
-        title="New Event"
-      />
-      <View style={styles.headerDivider} />
-
-      <ScrollView
-        automaticallyAdjustKeyboardInsets
-        contentContainerStyle={styles.content}
-        contentInsetAdjustmentBehavior="automatic"
-        keyboardDismissMode="interactive"
-        keyboardShouldPersistTaps="handled"
-        showsVerticalScrollIndicator={false}
+    <SafeAreaView style={styles.screen} edges={['top']}>
+      <KeyboardAvoidingView
+        style={styles.screen}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-        <View style={styles.form}>
-          <View style={styles.dropdownField}>
-            <Pressable
-              accessibilityHint="Opens the event type options"
-              accessibilityLabel="Event type"
-              accessibilityRole="button"
-              accessibilityState={{ expanded: isEventTypeOpen }}
-              onPress={() => setIsEventTypeOpen((current) => !current)}
-              style={({ pressed }) => [
-                styles.dropdownTrigger,
-                pressed ? styles.pressed : null,
-              ]}
-            >
-              <Text style={styles.dropdownValue}>
-                {eventType ?? 'Event type'}
-              </Text>
-              <ChevronDown color="#1a1512" size={20} />
-            </Pressable>
+        <ModalTopBar
+          color={sectionColors.events}
+          onClose={() => router.back()}
+          onSave={handleSave}
+          title="New Event"
+        />
+        <Divider color={sectionColors.events} />
 
-            {isEventTypeOpen ? (
-              <View style={styles.dropdownMenu}>
-                {EVENT_TYPE_OPTIONS.map((option) => {
-                  const isSelected = option === eventType;
+        <ScrollView
+          automaticallyAdjustKeyboardInsets
+          contentContainerStyle={styles.content}
+          contentInsetAdjustmentBehavior="automatic"
+          keyboardDismissMode="interactive"
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={styles.form}>
+            <form.Field name="title">
+              {(field) => (
+                <Input
+                  label="Title"
+                  onBlur={field.handleBlur}
+                  onChangeText={field.handleChange}
+                  placeholder="Give this event a memorable title..."
+                  required
+                  value={field.state.value}
+                />
+              )}
+            </form.Field>
+            {hasTriedSubmit && fieldErrors.title?.[0] ? (
+              <Text style={styles.errorText}>{fieldErrors.title[0]}</Text>
+            ) : null}
 
-                  return (
-                    <Pressable
-                      key={option}
-                      onPress={() => {
-                        setEventType(option);
-                        setIsEventTypeOpen(false);
-                      }}
-                      style={({ pressed }) => [
-                        styles.dropdownOption,
-                        isSelected ? styles.dropdownOptionSelected : null,
-                        pressed ? styles.pressed : null,
-                      ]}
-                    >
-                      <Text
-                        style={[
-                          styles.dropdownOptionLabel,
-                          isSelected
-                            ? styles.dropdownOptionLabelSelected
-                            : null,
-                        ]}
-                      >
-                        {option}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
+            <form.Field name="occurredAt">
+              {(field) => (
+                <DatePicker
+                  color={sectionColors.events}
+                  label="Date"
+                  onChange={field.handleChange}
+                  required
+                  value={field.state.value}
+                />
+              )}
+            </form.Field>
+            {hasTriedSubmit && fieldErrors.occurredAt?.[0] ? (
+              <Text style={styles.errorText}>{fieldErrors.occurredAt[0]}</Text>
+            ) : null}
+
+            <form.Field name="location">
+              {(field) => (
+                <Input
+                  label="Location"
+                  onBlur={field.handleBlur}
+                  onChangeText={field.handleChange}
+                  placeholder="Where did this take place?"
+                  required
+                  value={field.state.value}
+                />
+              )}
+            </form.Field>
+            {hasTriedSubmit && fieldErrors.location?.[0] ? (
+              <Text style={styles.errorText}>{fieldErrors.location[0]}</Text>
+            ) : null}
+
+            <form.Field name="mood">
+              {(field) => (
+                <Field label="Mood" required>
+                  <View style={styles.moodGrid}>
+                    {MOOD_OPTIONS.map((option) => (
+                      <Chip
+                        key={option}
+                        color={sectionColors.events}
+                        isSelected={field.state.value === option}
+                        label={option}
+                        setIsSelected={() => field.handleChange(option)}
+                        style={styles.moodChip}
+                      />
+                    ))}
+                  </View>
+                </Field>
+              )}
+            </form.Field>
+            {hasTriedSubmit && fieldErrors.mood?.[0] ? (
+              <Text style={styles.errorText}>{fieldErrors.mood[0]}</Text>
+            ) : null}
+
+            <form.Field name="notes">
+              {(field) => (
+                <Input
+                  label="Notes"
+                  minRows={4}
+                  onBlur={field.handleBlur}
+                  onChangeText={field.handleChange}
+                  placeholder="Add a few details you want to remember..."
+                  value={field.state.value}
+                  variant="textarea"
+                />
+              )}
+            </form.Field>
+            {hasTriedSubmit && fieldErrors.notes?.[0] ? (
+              <Text style={styles.errorText}>{fieldErrors.notes[0]}</Text>
+            ) : null}
+
+            <AddImageField
+              color={sectionColors.events}
+              onChange={setPhotos}
+              value={photos}
+            />
+
+            {submitError ? (
+              <Text style={styles.errorText}>{submitError}</Text>
+            ) : null}
+
+            {isSaving ? (
+              <View style={styles.submittingRow}>
+                <ActivityIndicator color={sectionColors.events} />
+                <Text style={styles.submittingText}>Saving event...</Text>
               </View>
             ) : null}
           </View>
-          <Input
-            label="Title"
-            onChangeText={setTitle}
-            placeholder="Give this date a memorable title..."
-            required
-            value={title}
-          />
-          <DatePicker
-            color={sectionColors.events}
-            label="Date"
-            onChange={setEventDate}
-            required
-            value={eventDate}
-          />
-          <Input
-            label="Location"
-            onChangeText={setLocation}
-            placeholder="Where did this take place?"
-            required
-            value={location}
-          />
-          <Field label="Mood">
-            <View style={styles.moodGrid}>
-              {MOOD_OPTIONS.map((option) => (
-                <Chip
-                  key={option}
-                  color={sectionColors.events}
-                  isSelected={mood === option}
-                  label={option}
-                  setIsSelected={() => setMood(option)}
-                  style={styles.moodChip}
-                />
-              ))}
-            </View>
-          </Field>
-          <Input
-            label="Description"
-            onChangeText={setDescription}
-            placeholder="Describe this special moment..."
-            required
-            variant="textarea"
-            minRows={4}
-            value={description}
-          />
-          <AddImageField
-            color={sectionColors.events}
-            value={photos}
-            onChange={setPhotos}
-          />
-        </View>
-      </ScrollView>
-    </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  screen: {
     flex: 1,
     backgroundColor: baseColors.bg,
   },
-  headerDivider: {
-    height: StyleSheet.hairlineWidth,
-    backgroundColor: 'rgba(168, 155, 255, 0.35)',
-  },
   content: {
-    paddingHorizontal: 18,
+    paddingHorizontal: space.lg,
     paddingTop: space.lg,
     paddingBottom: space.xxl,
     gap: space.xl,
   },
   form: {
     gap: space.xl,
-  },
-  pressed: {
-    opacity: 0.9,
-  },
-  dropdownField: {
-    gap: space.sm,
-  },
-  dropdownTrigger: {
-    minHeight: 36,
-    borderRadius: radius.full,
-    backgroundColor: sectionColors.events,
-    paddingHorizontal: space.lg,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  dropdownValue: {
-    color: '#1a1512',
-    fontFamily: textTheme.family.semiBold,
-    fontSize: textTheme.size.sm,
-    lineHeight: textTheme.lineHeight.sm,
-  },
-  dropdownMenu: {
-    backgroundColor: baseColors.card,
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    borderColor: 'rgba(168, 155, 255, 0.25)',
-    overflow: 'hidden',
-  },
-  dropdownOption: {
-    paddingHorizontal: space.lg,
-    paddingVertical: space.md,
-  },
-  dropdownOptionSelected: {
-    backgroundColor: 'rgba(168, 155, 255, 0.12)',
-  },
-  dropdownOptionLabel: {
-    color: baseColors.text,
-    fontFamily: textTheme.family.medium,
-    fontSize: textTheme.size.sm,
-    lineHeight: textTheme.lineHeight.sm,
-  },
-  dropdownOptionLabelSelected: {
-    color: sectionColors.events,
-    fontFamily: textTheme.family.semiBold,
   },
   moodGrid: {
     flexDirection: 'row',
@@ -242,5 +298,23 @@ const styles = StyleSheet.create({
     minHeight: 36,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  errorText: {
+    color: baseColors.textError,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.xs,
+    lineHeight: textTheme.lineHeight.xs,
+    marginTop: -space.md,
+  },
+  submittingRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: space.sm,
+  },
+  submittingText: {
+    color: baseColors.textSoft,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,7 @@ import {
   PlusJakartaSans_600SemiBold,
   PlusJakartaSans_700Bold,
 } from '@expo-google-fonts/plus-jakarta-sans';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useFonts } from 'expo-font';
 import { Redirect, Stack, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -15,6 +16,16 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { baseColors } from '../theme/colors';
 
 export default function RootLayout() {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: 1,
+          },
+        },
+      }),
+  );
   const [loaded] = useFonts({
     PlusJakartaSans_400Regular,
     PlusJakartaSans_500Medium,
@@ -71,19 +82,21 @@ export default function RootLayout() {
   }
 
   return (
-    <SafeAreaProvider>
-      <StatusBar style="light" />
-      <Stack
-        screenOptions={{
-          headerShown: false,
-          contentStyle: { backgroundColor: baseColors.bg },
-        }}
-      >
-        <Stack.Screen name="sign-in" />
-        <Stack.Screen name="sign-up" />
-        <Stack.Screen name="(tabs)" />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-    </SafeAreaProvider>
+    <QueryClientProvider client={queryClient}>
+      <SafeAreaProvider>
+        <StatusBar style="light" />
+        <Stack
+          screenOptions={{
+            headerShown: false,
+            contentStyle: { backgroundColor: baseColors.bg },
+          }}
+        >
+          <Stack.Screen name="sign-in" />
+          <Stack.Screen name="sign-up" />
+          <Stack.Screen name="(tabs)" />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+      </SafeAreaProvider>
+    </QueryClientProvider>
   );
 }

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,282 @@
+import type { SelectedImage } from '@/components/ui/AddImageField';
+import { supabase } from './supabase';
+
+export const eventKeys = {
+  all: ['events'] as const,
+  lists: () => [...eventKeys.all, 'list'] as const,
+  list: () => [...eventKeys.lists(), 'current-user'] as const,
+  details: () => [...eventKeys.all, 'detail'] as const,
+  detail: (eventId: string) => [...eventKeys.details(), eventId] as const,
+};
+
+export type CreateEventInput = {
+  title: string;
+  occurredAt: Date;
+  location: string;
+  mood: string;
+  notes: string;
+  photos: SelectedImage[];
+};
+
+export type EventListItem = {
+  id: string;
+  title: string;
+  occurredOn: string;
+  locationText: string | null;
+  mood: string | null;
+  coverImage?: string;
+};
+
+export type EventDetail = {
+  id: string;
+  title: string;
+  occurredOn: string;
+  locationText: string | null;
+  mood: string | null;
+  notes: string | null;
+  photos: string[];
+};
+
+type LinkedPhotoRow = {
+  event_id?: string | null;
+  photos?:
+    | { storage_path?: string | null }
+    | { storage_path?: string | null }[]
+    | null;
+};
+
+function normalizeOptionalText(value: string): string | null {
+  const trimmed = value.trim();
+
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function resolveStoragePath(link: LinkedPhotoRow): string | null {
+  const relatedPhoto = Array.isArray(link.photos)
+    ? link.photos[0]
+    : link.photos;
+
+  return relatedPhoto?.storage_path ?? null;
+}
+
+async function getCurrentUserId(): Promise<string | null> {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return user?.id ?? null;
+}
+
+async function getPersonalGroupIdForUser(userId: string): Promise<string> {
+  const { data: groups, error } = await supabase
+    .from('groups')
+    .select('id, name, group_kind')
+    .eq('personal_owner_user_id', userId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const personalGroup =
+    groups?.find((group) => group.group_kind === 'personal') ??
+    groups?.find((group) => group.name?.toLowerCase() === 'personal') ??
+    groups?.[0];
+
+  if (!personalGroup?.id) {
+    throw new Error(
+      'No group found for this user yet. The personal group needs to exist before creating events.',
+    );
+  }
+
+  return personalGroup.id;
+}
+
+export async function listEventsForCurrentUser(): Promise<EventListItem[]> {
+  const userId = await getCurrentUserId();
+
+  if (!userId) {
+    return [];
+  }
+
+  const { data: events, error } = await supabase
+    .from('events')
+    .select('id, title, occurred_on, location_text, mood, created_at')
+    .eq('created_by', userId)
+    .order('occurred_on', { ascending: false })
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const rows = events ?? [];
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const eventIds = rows.map((event) => event.id);
+  const { data: links, error: linksError } = await supabase
+    .from('event_photos')
+    .select('event_id, sort_order, photos(storage_path)')
+    .in('event_id', eventIds)
+    .order('event_id', { ascending: true })
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true });
+
+  if (linksError) {
+    throw new Error(linksError.message);
+  }
+
+  const coverImageByEventId = new Map<string, string>();
+
+  for (const link of (links ?? []) as LinkedPhotoRow[]) {
+    const eventId = link.event_id;
+    const storagePath = resolveStoragePath(link);
+
+    if (!eventId || !storagePath || coverImageByEventId.has(eventId)) {
+      continue;
+    }
+
+    coverImageByEventId.set(eventId, storagePath);
+  }
+
+  return rows.map((event) => ({
+    id: event.id,
+    title: event.title,
+    occurredOn: event.occurred_on,
+    locationText: event.location_text,
+    mood: event.mood,
+    coverImage: coverImageByEventId.get(event.id),
+  }));
+}
+
+export async function createEvent(input: CreateEventInput): Promise<string> {
+  const userId = await getCurrentUserId();
+
+  if (!userId) {
+    throw new Error('You must be signed in to create an event.');
+  }
+
+  const groupId = await getPersonalGroupIdForUser(userId);
+  const { data: insertedEvent, error: eventError } = await supabase
+    .from('events')
+    .insert({
+      group_id: groupId,
+      created_by: userId,
+      title: input.title.trim(),
+      occurred_on: input.occurredAt.toISOString().slice(0, 10),
+      location_text: normalizeOptionalText(input.location),
+      mood: normalizeOptionalText(input.mood),
+      notes: normalizeOptionalText(input.notes),
+    })
+    .select('id')
+    .single();
+
+  if (eventError) {
+    throw new Error(eventError.message);
+  }
+
+  if (!insertedEvent?.id) {
+    throw new Error('Could not create event.');
+  }
+
+  const persistedPhotoCandidates = input.photos.filter((photo) =>
+    Boolean(photo.storagePath),
+  );
+
+  if (persistedPhotoCandidates.length === 0) {
+    return insertedEvent.id;
+  }
+
+  const { data: insertedPhotos, error: photosError } = await supabase
+    .from('photos')
+    .insert(
+      persistedPhotoCandidates.map((photo) => ({
+        group_id: groupId,
+        uploaded_by: userId,
+        storage_path: photo.storagePath!,
+        caption: null,
+        taken_at: input.occurredAt.toISOString(),
+      })),
+    )
+    .select('id');
+
+  if (photosError) {
+    throw new Error(photosError.message);
+  }
+
+  if (!insertedPhotos?.length) {
+    return insertedEvent.id;
+  }
+
+  const { error: linksError } = await supabase.from('event_photos').insert(
+    insertedPhotos.map((photo, index) => ({
+      group_id: groupId,
+      event_id: insertedEvent.id,
+      photo_id: photo.id,
+      sort_order: index,
+    })),
+  );
+
+  if (linksError) {
+    throw new Error(linksError.message);
+  }
+
+  return insertedEvent.id;
+}
+
+export async function getEventById(
+  eventId: string,
+): Promise<EventDetail | null> {
+  const userId = await getCurrentUserId();
+
+  if (!userId) {
+    return null;
+  }
+
+  const { data: event, error } = await supabase
+    .from('events')
+    .select('id, title, occurred_on, location_text, mood, notes')
+    .eq('id', eventId)
+    .eq('created_by', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!event) {
+    return null;
+  }
+
+  const { data: links, error: linksError } = await supabase
+    .from('event_photos')
+    .select('sort_order, photos(storage_path)')
+    .eq('event_id', eventId)
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true });
+
+  if (linksError) {
+    throw new Error(linksError.message);
+  }
+
+  const photos = (links ?? [])
+    .map((link) => resolveStoragePath(link))
+    .filter((path): path is string => Boolean(path));
+
+  return {
+    id: event.id,
+    title: event.title,
+    occurredOn: event.occurred_on,
+    locationText: event.location_text,
+    mood: event.mood,
+    notes: event.notes,
+    photos,
+  };
+}

--- a/lib/validation/event.ts
+++ b/lib/validation/event.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const createEventSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, 'Title is required.')
+    .max(200, 'Title must be 200 characters or less.'),
+  occurredAt: z.date({
+    error: 'Date is required.',
+  }),
+  location: z
+    .string()
+    .trim()
+    .min(1, 'Location is required.')
+    .max(160, 'Location must be 160 characters or less.'),
+  mood: z
+    .string()
+    .trim()
+    .min(1, 'Mood is required.')
+    .max(80, 'Mood must be 80 characters or less.'),
+  notes: z.string().trim().max(1200, 'Notes must be 1200 characters or less.'),
+});
+
+export type CreateEventValues = z.infer<typeof createEventSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@rn-primitives/slot": "^1.4.0",
         "@supabase/supabase-js": "^2.103.3",
         "@tanstack/react-form": "^1.29.0",
+        "@tanstack/react-query": "^5.99.2",
         "date-fns": "^4.1.0",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
@@ -3359,6 +3360,16 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
+      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-form": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@tanstack/react-form/-/react-form-1.29.0.tgz",
@@ -3397,6 +3408,22 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
+      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/store": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@rn-primitives/slot": "^1.4.0",
     "@supabase/supabase-js": "^2.103.3",
     "@tanstack/react-form": "^1.29.0",
+    "@tanstack/react-query": "^5.99.2",
     "date-fns": "^4.1.0",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",


### PR DESCRIPTION
## What changed

This PR replaces the scaffolded `events` flow with a working CRUD implementation that follows the existing `moments` pattern while layering TanStack Query on top of the Supabase JavaScript query builder.

### Data layer

- added `lib/events.ts` with Supabase-backed helpers for:
  - listing current-user events
  - creating events
  - fetching a single event with linked photos
- kept the existing Supabase JS query builder approach instead of moving to RPCs or a different data client
- added `eventKeys` query keys for list/detail invalidation and reuse
- added `lib/validation/event.ts` for event form validation

### Query setup

- added `@tanstack/react-query`
- wrapped the app in a shared `QueryClientProvider` in `app/_layout.tsx`

### Events UI

- replaced the scaffolded events index with a real queried list screen
- replaced the scaffolded new-event screen with a validated create flow
- replaced the scaffolded detail screen with a real queried detail view
- updated events navigation so the detail screen hides the tab header and uses a full-screen presentation that matches the design direction more closely

## Why it changed

The `events` area was still scaffolded, while `moments` already had a functioning data flow. The goal here was to bring `events` up to the same functional level, keep implementation patterns consistent with the rest of the app, and introduce TanStack Query in a focused way around the existing Supabase data access.

## Schema alignment

This implementation is aligned to the shared table definitions:

- `events`
- `event_photos`
- `photos`
- `groups`

A few parts of the original draft UI were adjusted to match the actual schema:

- event persistence uses `title`, `occurred_on`, `location_text`, `mood`, and `notes`
- the earlier placeholder `event type` field was removed because there is no matching persisted column in the provided schema
- photo links are written through `event_photos`

## Behavior notes

- event creation uses the same personal-group lookup strategy as `moments`
- list and detail views fetch linked photo storage paths through the join table
- after event creation, query invalidation runs in the background instead of blocking submit completion, so save success is not coupled to a follow-up refetch

## User impact

Users can now:

- view a real events list
- create events with validation
- save location, mood, notes, and linked photos
- open an event detail screen backed by real data

## Validation

Ran:

- `npm run format:check`
- `npm run lint`
- `npx tsc --noEmit`

## Follow-ups

Possible future improvements, outside the scope of this PR:

- upload photo assets before save so newly selected local images persist end-to-end
- add edit/delete flows for events if needed
- add a live UI pass in the app to fine-tune visual parity with the Figma reference
