### PR TITLE
feat: add global spaces support

### DIFF
--- a/app/(tabs)/events/[id].tsx
+++ b/app/(tabs)/events/[id].tsx
@@ -1,5 +1,6 @@
 import Divider from '@/components/ui/Divider';
 import { Text } from '@/components/ui/Text';
+import { useActiveGroup } from '@/hooks/useActiveGroup';
 import { useEventDetailQuery } from '@/hooks/useEvents';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { radius } from '@/theme/radius';
@@ -35,10 +36,11 @@ function formatOccurredOn(dateValue: string): string {
 
 export default function EventDetailScreen() {
   const insets = useSafeAreaInsets();
+  const { activeGroup, isLoading: isLoadingGroups } = useActiveGroup();
   const params = useLocalSearchParams<{ id?: string | string[] }>();
   const rawId = params.id;
   const eventId = Array.isArray(rawId) ? rawId[0] : rawId;
-  const eventQuery = useEventDetailQuery(eventId);
+  const eventQuery = useEventDetailQuery(eventId, activeGroup?.id);
   const displayDate = eventQuery.data?.occurredOn
     ? formatOccurredOn(eventQuery.data.occurredOn)
     : '';
@@ -54,7 +56,7 @@ export default function EventDetailScreen() {
         : null;
   const hasNotes = Boolean(eventQuery.data?.notes?.trim());
 
-  if (eventQuery.isPending) {
+  if (isLoadingGroups || eventQuery.isPending) {
     return (
       <View style={styles.screenCentered}>
         <ActivityIndicator color={sectionColors.events} />

--- a/app/(tabs)/events/index.tsx
+++ b/app/(tabs)/events/index.tsx
@@ -1,5 +1,4 @@
 import { Card } from '@/components/ui/Card';
-import Header from '@/components/ui/Header';
 import { Text } from '@/components/ui/Text';
 import { useActiveGroup } from '@/hooks/useActiveGroup';
 import { useEventsQuery } from '@/hooks/useEvents';
@@ -9,10 +8,10 @@ import { text } from '@/theme/type';
 import { type Href, Link } from 'expo-router';
 import { Plus } from 'lucide-react-native';
 import {
+  ActivityIndicator,
   Pressable,
   ScrollView,
   StyleSheet,
-  ActivityIndicator,
   View,
 } from 'react-native';
 
@@ -33,8 +32,11 @@ function formatOccurredOn(dateValue: string): string {
 }
 
 export default function EventsIndexScreen() {
-  const { activeGroup, errorMessage: groupError, isLoading: isLoadingGroups } =
-    useActiveGroup();
+  const {
+    activeGroup,
+    errorMessage: groupError,
+    isLoading: isLoadingGroups,
+  } = useActiveGroup();
   const eventsQuery = useEventsQuery(activeGroup?.id);
 
   const events = eventsQuery.data ?? [];
@@ -48,15 +50,10 @@ export default function EventsIndexScreen() {
   const activeGroupLabel =
     activeGroup?.groupKind === 'personal'
       ? 'Personal'
-      : activeGroup?.name ?? 'this space';
+      : (activeGroup?.name ?? 'this space');
 
   return (
     <View style={styles.container}>
-      <Header
-        title="Events"
-        color={sectionColors.events}
-        tagLine="Insert very meaningful text here"
-      />
       <ScrollView
         style={styles.scrollView}
         contentContainerStyle={styles.content}
@@ -73,10 +70,12 @@ export default function EventsIndexScreen() {
           <Text style={styles.errorText}>{loadError}</Text>
         ) : null}
 
-        {!isLoadingGroups && !eventsQuery.isPending && !loadError && events.length === 0 ? (
+        {!isLoadingGroups &&
+        !eventsQuery.isPending &&
+        !loadError &&
+        events.length === 0 ? (
           <Text style={styles.emptyText}>
-            No events in {activeGroupLabel} yet. Tap + to create your first
-            one.
+            No events in {activeGroupLabel} yet. Tap + to create your first one.
           </Text>
         ) : null}
 

--- a/app/(tabs)/events/index.tsx
+++ b/app/(tabs)/events/index.tsx
@@ -1,5 +1,7 @@
 import { Card } from '@/components/ui/Card';
+import Header from '@/components/ui/Header';
 import { Text } from '@/components/ui/Text';
+import { useActiveGroup } from '@/hooks/useActiveGroup';
 import { useEventsQuery } from '@/hooks/useEvents';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
@@ -7,10 +9,10 @@ import { text } from '@/theme/type';
 import { type Href, Link } from 'expo-router';
 import { Plus } from 'lucide-react-native';
 import {
-  ActivityIndicator,
   Pressable,
   ScrollView,
   StyleSheet,
+  ActivityIndicator,
   View,
 } from 'react-native';
 
@@ -31,67 +33,79 @@ function formatOccurredOn(dateValue: string): string {
 }
 
 export default function EventsIndexScreen() {
-  const eventsQuery = useEventsQuery();
+  const { activeGroup, errorMessage: groupError, isLoading: isLoadingGroups } =
+    useActiveGroup();
+  const eventsQuery = useEventsQuery(activeGroup?.id);
 
   const events = eventsQuery.data ?? [];
   const loadError =
-    eventsQuery.error instanceof Error
+    groupError ??
+    (eventsQuery.error instanceof Error
       ? eventsQuery.error.message
       : eventsQuery.error
         ? 'Failed to load events.'
-        : null;
+        : null);
+  const activeGroupLabel =
+    activeGroup?.groupKind === 'personal'
+      ? 'Personal'
+      : activeGroup?.name ?? 'this space';
 
   return (
     <View style={styles.container}>
-      <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
-        <View style={styles.content}>
-          {eventsQuery.isPending ? (
-            <ActivityIndicator
-              color={sectionColors.events}
-              style={styles.loader}
-            />
-          ) : null}
+      <Header
+        title="Events"
+        color={sectionColors.events}
+        tagLine="Insert very meaningful text here"
+      />
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        {isLoadingGroups || eventsQuery.isPending ? (
+          <ActivityIndicator
+            color={sectionColors.events}
+            style={styles.loader}
+          />
+        ) : null}
 
-          {!eventsQuery.isPending && loadError ? (
-            <Text style={styles.errorText}>{loadError}</Text>
-          ) : null}
+        {!isLoadingGroups && !eventsQuery.isPending && loadError ? (
+          <Text style={styles.errorText}>{loadError}</Text>
+        ) : null}
 
-          {!eventsQuery.isPending && !loadError && events.length === 0 ? (
-            <Text style={styles.emptyText}>
-              No events yet. Tap + to create your first one.
-            </Text>
-          ) : null}
+        {!isLoadingGroups && !eventsQuery.isPending && !loadError && events.length === 0 ? (
+          <Text style={styles.emptyText}>
+            No events in {activeGroupLabel} yet. Tap + to create your first
+            one.
+          </Text>
+        ) : null}
 
-          {!eventsQuery.isPending && !loadError
-            ? events.map((event) => (
-                <Link
-                  asChild
-                  href={`/events/${event.id}` as Href}
-                  key={event.id}
+        {!isLoadingGroups && !eventsQuery.isPending && !loadError
+          ? events.map((event) => (
+              <Link asChild href={`/events/${event.id}` as Href} key={event.id}>
+                <Pressable
+                  accessibilityHint="Opens this event"
+                  accessibilityRole="button"
+                  style={({ pressed }) => [
+                    styles.cardPressable,
+                    pressed ? styles.cardPressed : null,
+                  ]}
                 >
-                  <Pressable
-                    accessibilityHint="Opens this event"
-                    accessibilityRole="button"
-                    style={({ pressed }) => [
-                      styles.cardPressable,
-                      pressed ? styles.cardPressed : null,
-                    ]}
-                  >
-                    <Card
-                      color={sectionColors.events}
-                      coverImage={event.coverImage ?? FALLBACK_COVER_IMAGE}
-                      date={formatOccurredOn(event.occurredOn)}
-                      location={event.locationText ?? 'No location added'}
-                      title={event.title}
-                      type={event.mood ?? 'No mood set'}
-                      variant="compressed"
-                    />
-                  </Pressable>
-                </Link>
-              ))
-            : null}
-        </View>
+                  <Card
+                    color={sectionColors.events}
+                    coverImage={event.coverImage ?? FALLBACK_COVER_IMAGE}
+                    date={formatOccurredOn(event.occurredOn)}
+                    location={event.locationText ?? 'No location added'}
+                    title={event.title}
+                    type={event.mood ?? 'No mood set'}
+                    variant="compressed"
+                  />
+                </Pressable>
+              </Link>
+            ))
+          : null}
       </ScrollView>
+
       <Link href="/events/new" asChild>
         <Pressable accessibilityRole="button" style={styles.createButton}>
           <Plus color={baseColors.bg} size={28} strokeWidth={2.4} />
@@ -106,10 +120,12 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: baseColors.bg,
   },
+  scrollView: {
+    flex: 1,
+  },
   content: {
     gap: space.md + space.xs,
     paddingHorizontal: space.lg,
-    paddingTop: space.xl,
     paddingBottom: 110,
   },
   loader: {

--- a/app/(tabs)/events/new.tsx
+++ b/app/(tabs)/events/new.tsx
@@ -8,6 +8,7 @@ import Chip from '@/components/ui/Chip';
 import Divider from '@/components/ui/Divider';
 import { Field, Input } from '@/components/ui/Input';
 import { Text } from '@/components/ui/Text';
+import { useActiveGroup } from '@/hooks/useActiveGroup';
 import { useCreateEventMutation } from '@/hooks/useEvents';
 import {
   createEventSchema,
@@ -59,6 +60,7 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
 }
 
 export default function NewEventScreen() {
+  const { activeGroup } = useActiveGroup();
   const [photos, setPhotos] = useState<SelectedImage[]>([]);
   const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -80,9 +82,14 @@ export default function NewEventScreen() {
         throw new Error(parsed.error.issues[0]?.message ?? 'Invalid input.');
       }
 
+      if (!activeGroup?.id) {
+        throw new Error('Choose a space before saving this event.');
+      }
+
       try {
         await createEventMutation.mutateAsync({
           ...parsed.data,
+          groupId: activeGroup.id,
           photos,
         });
       } catch (error) {
@@ -116,6 +123,11 @@ export default function NewEventScreen() {
     const parsed = createEventSchema.safeParse(form.state.values);
 
     if (!parsed.success) {
+      return;
+    }
+
+    if (!activeGroup?.id) {
+      setSaveError('Choose a space before saving this event.');
       return;
     }
 

--- a/app/(tabs)/moments/[id].tsx
+++ b/app/(tabs)/moments/[id].tsx
@@ -1,5 +1,6 @@
 import Divider from '@/components/ui/Divider';
 import { Text } from '@/components/ui/Text';
+import { useActiveGroup } from '@/hooks/useActiveGroup';
 import { useMomentDetailQuery } from '@/hooks/useMoments';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { radius } from '@/theme/radius';
@@ -49,10 +50,11 @@ function formatMomentType(value: string | null): string {
 
 export default function MomentDetailScreen() {
   const { width } = useWindowDimensions();
+  const { activeGroup, isLoading: isLoadingGroups } = useActiveGroup();
   const params = useLocalSearchParams<{ id?: string | string[] }>();
   const rawId = params.id;
   const momentId = Array.isArray(rawId) ? rawId[0] : rawId;
-  const momentQuery = useMomentDetailQuery(momentId);
+  const momentQuery = useMomentDetailQuery(momentId, activeGroup?.id);
   const moment = momentQuery.data;
   const displayDate = moment ? formatOccurredOn(moment.occurredOn) : '';
   const displayType = formatMomentType(moment?.category ?? null);
@@ -77,7 +79,7 @@ export default function MomentDetailScreen() {
     setActiveBannerIndex(nextIndex);
   }
 
-  if (momentQuery.isPending) {
+  if (isLoadingGroups || momentQuery.isPending) {
     return (
       <View style={styles.screenCentered}>
         <ActivityIndicator color={sectionColors.moments} />

--- a/app/(tabs)/moments/index.tsx
+++ b/app/(tabs)/moments/index.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@/components/ui/Card';
 import { Text } from '@/components/ui/Text';
+import { useActiveGroup } from '@/hooks/useActiveGroup';
 import { useMomentsQuery } from '@/hooks/useMoments';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
@@ -11,8 +12,8 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
-  View,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 const FALLBACK_COVER_IMAGE = require('@/assets/images/fallbackImage.png');
 
@@ -43,72 +44,86 @@ function formatMomentType(value: string | null): string {
 }
 
 export default function MomentsScreen() {
-  const momentsQuery = useMomentsQuery();
+  const { activeGroup, errorMessage: groupError, isLoading: isLoadingGroups } =
+    useActiveGroup();
+  const momentsQuery = useMomentsQuery(activeGroup?.id);
   const moments = momentsQuery.data ?? [];
   const loadError =
-    momentsQuery.error instanceof Error
+    groupError ??
+    (momentsQuery.error instanceof Error
       ? momentsQuery.error.message
       : momentsQuery.error
         ? 'Failed to load moments.'
-        : null;
+        : null);
+  const activeGroupLabel =
+    activeGroup?.groupKind === 'personal'
+      ? 'Personal'
+      : activeGroup?.name ?? 'this space';
 
   return (
-    <View style={styles.container}>
-      <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
-        <View style={styles.content}>
-          {momentsQuery.isPending ? (
-            <ActivityIndicator
-              color={sectionColors.moments}
-              style={styles.loader}
-            />
-          ) : null}
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+      >
+        {isLoadingGroups || momentsQuery.isPending ? (
+          <ActivityIndicator
+            color={sectionColors.moments}
+            style={styles.loader}
+          />
+        ) : null}
 
-          {!momentsQuery.isPending && loadError ? (
-            <Text style={styles.errorText}>{loadError}</Text>
-          ) : null}
+        {!isLoadingGroups && !momentsQuery.isPending && loadError ? (
+          <Text style={styles.errorText}>{loadError}</Text>
+        ) : null}
 
-          {!momentsQuery.isPending && !loadError && moments.length === 0 ? (
-            <Text style={styles.emptyText}>
-              No moments yet. Tap + to create your first one.
-            </Text>
-          ) : null}
+        {!isLoadingGroups &&
+        !momentsQuery.isPending &&
+        !loadError &&
+        moments.length === 0 ? (
+          <Text style={styles.emptyText}>
+            No moments in {activeGroupLabel} yet. Tap + to create your first
+            one.
+          </Text>
+        ) : null}
 
-          {!momentsQuery.isPending && !loadError
-            ? moments.map((moment) => (
-                <Link
-                  asChild
-                  href={`/moments/${moment.id}` as Href}
-                  key={moment.id}
+        {!isLoadingGroups && !momentsQuery.isPending && !loadError
+          ? moments.map((moment) => (
+              <Link
+                asChild
+                href={`/moments/${moment.id}` as Href}
+                key={moment.id}
+              >
+                <Pressable
+                  accessibilityHint="Opens this moment"
+                  accessibilityRole="button"
+                  style={({ pressed }) => [
+                    styles.cardPressable,
+                    pressed ? styles.cardPressed : null,
+                  ]}
                 >
-                  <Pressable
-                    accessibilityHint="Opens this moment"
-                    accessibilityRole="button"
-                    style={({ pressed }) => [
-                      styles.cardPressable,
-                      pressed ? styles.cardPressed : null,
-                    ]}
-                  >
-                    <Card
-                      color={sectionColors.moments}
-                      coverImage={moment.coverImage ?? FALLBACK_COVER_IMAGE}
-                      date={formatOccurredOn(moment.occurredOn)}
-                      description={moment.description ?? ''}
-                      title={moment.title}
-                      type={formatMomentType(moment.category)}
-                      variant="default"
-                    />
-                  </Pressable>
-                </Link>
-              ))
-            : null}
-        </View>
+                  <Card
+                    color={sectionColors.moments}
+                    coverImage={moment.coverImage ?? FALLBACK_COVER_IMAGE}
+                    date={formatOccurredOn(moment.occurredOn)}
+                    description={moment.description ?? ''}
+                    title={moment.title}
+                    type={formatMomentType(moment.category)}
+                    variant="default"
+                  />
+                </Pressable>
+              </Link>
+            ))
+          : null}
       </ScrollView>
+
       <Link href="/moments/new" asChild>
         <Pressable accessibilityRole="button" style={styles.createButton}>
           <Plus color={baseColors.bg} size={28} strokeWidth={2.4} />
         </Pressable>
       </Link>
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -120,7 +135,6 @@ const styles = StyleSheet.create({
   content: {
     gap: space.md + space.xs,
     paddingHorizontal: space.lg,
-    paddingTop: space.xl,
     paddingBottom: 110,
   },
   loader: {

--- a/app/(tabs)/moments/new.tsx
+++ b/app/(tabs)/moments/new.tsx
@@ -8,6 +8,7 @@ import Divider from '@/components/ui/Divider';
 import { Dropdown } from '@/components/ui/Dropdown';
 import { Input } from '@/components/ui/Input';
 import { Text } from '@/components/ui/Text';
+import { useActiveGroup } from '@/hooks/useActiveGroup';
 import { useCreateMomentMutation } from '@/hooks/useMoments';
 import {
   type CreateMomentValues,
@@ -52,6 +53,7 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
 }
 
 export default function NewMomentScreen() {
+  const { activeGroup } = useActiveGroup();
   const [photos, setPhotos] = useState<SelectedImage[]>([]);
   const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -81,9 +83,14 @@ export default function NewMomentScreen() {
         throw new Error(parsed.error.issues[0]?.message ?? 'Invalid input.');
       }
 
+      if (!activeGroup?.id) {
+        throw new Error('Choose a space before saving this moment.');
+      }
+
       try {
         await createMomentMutation.mutateAsync({
           ...parsed.data,
+          groupId: activeGroup.id,
           photos,
         });
       } catch (error) {
@@ -115,6 +122,11 @@ export default function NewMomentScreen() {
     setSaveError(null);
     const parsed = createMomentSchema.safeParse(form.state.values);
     if (!parsed.success) {
+      return;
+    }
+
+    if (!activeGroup?.id) {
+      setSaveError('Choose a space before saving this moment.');
       return;
     }
 

--- a/components/GroupScopePicker.tsx
+++ b/components/GroupScopePicker.tsx
@@ -1,0 +1,147 @@
+import { useActiveGroup } from '@/hooks/useActiveGroup';
+import { type UserGroup } from '@/services/groups';
+import { baseColors } from '@/theme/colors';
+import { space } from '@/theme/space';
+import { text as textTheme } from '@/theme/type';
+import { ActivityIndicator, StyleSheet, View, type ViewStyle } from 'react-native';
+
+import { Select } from './ui/Select';
+import { Text } from './ui/Text';
+
+type GroupScopePickerProps = {
+  color: string;
+  label?: string;
+  sheetTitle?: string;
+  size?: 'compact' | 'default' | 'header';
+  style?: ViewStyle;
+};
+
+function formatGroupLabel(group: UserGroup): string {
+  if (group.groupKind === 'personal') {
+    return 'Personal';
+  }
+
+  return group.name;
+}
+
+function formatGroupDescription(group: UserGroup): string {
+  if (group.groupKind === 'personal') {
+    return 'Private space for your own memories';
+  }
+
+  if (group.role === 'owner') {
+    return 'Shared space you manage with others';
+  }
+
+  return 'Shared space with group content';
+}
+
+export function GroupScopePicker({
+  color,
+  label,
+  sheetTitle,
+  size = 'default',
+  style,
+}: GroupScopePickerProps) {
+  const {
+    activeGroupId,
+    errorMessage,
+    groups,
+    isLoading,
+    setActiveGroupId,
+  } = useActiveGroup();
+
+  if (isLoading) {
+    return (
+      <View
+        style={[
+          size === 'header' ? styles.loadingRowHeader : styles.loadingRow,
+          style,
+        ]}
+      >
+        <ActivityIndicator color={color} size="small" />
+        {size === 'header' ? null : (
+          <Text style={styles.loadingText}>Loading your spaces...</Text>
+        )}
+      </View>
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <View style={[styles.messageCard, style]}>
+        <Text style={styles.errorText}>{errorMessage}</Text>
+      </View>
+    );
+  }
+
+  if (groups.length === 0) {
+    return (
+      <View style={[styles.messageCard, style]}>
+        <Text style={styles.emptyText}>No groups available yet.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <Select
+      color={color}
+      disabled={groups.length === 0}
+      label={label}
+      onChange={setActiveGroupId}
+      options={groups.map((group) => ({
+        label: formatGroupLabel(group),
+        value: group.id,
+        description: formatGroupDescription(group),
+      }))}
+      placeholder="Choose a space"
+      sheetTitle={sheetTitle}
+      size={size}
+      style={style}
+      value={activeGroupId ?? undefined}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  loadingRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: space.sm,
+  },
+  loadingRowHeader: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.06)',
+    borderCurve: 'continuous',
+    borderRadius: 999,
+    justifyContent: 'center',
+    minHeight: 34,
+    minWidth: 44,
+    paddingHorizontal: space.md,
+  },
+  loadingText: {
+    color: baseColors.textSoft,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  messageCard: {
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    borderCurve: 'continuous',
+    borderRadius: 22,
+    paddingHorizontal: space.lg,
+    paddingVertical: space.md,
+  },
+  errorText: {
+    color: baseColors.textError,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  emptyText: {
+    color: baseColors.textSoft,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+});

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -1,3 +1,4 @@
+import { GroupScopePicker } from '@/components/GroupScopePicker';
 import { Text } from '@/components/ui/Text';
 import { baseColors } from '@/theme/colors';
 import { space } from '@/theme/space';
@@ -13,7 +14,7 @@ interface HeaderProps {
   height?: number;
 }
 
-export const TAB_HEADER_CONTENT_HEIGHT = 88;
+export const TAB_HEADER_CONTENT_HEIGHT = 108;
 
 export default function Header({ title, tagLine, color, height }: HeaderProps) {
   return (
@@ -30,7 +31,14 @@ export default function Header({ title, tagLine, color, height }: HeaderProps) {
           >
             {title}
           </Text>
-          <CircleUser color={baseColors.text} size={24} />
+          <View style={styles.actions}>
+            <GroupScopePicker
+              color={color ?? baseColors.text}
+              sheetTitle="Switch space"
+              size="header"
+            />
+            <CircleUser color={baseColors.text} size={24} />
+          </View>
         </View>
         {tagLine && <Text style={styles.tagLine}>{tagLine}</Text>}
       </View>
@@ -44,20 +52,25 @@ const styles = StyleSheet.create({
     paddingTop: space.lg,
   },
   headerContainer: {
-    marginBottom: space.lg,
+    marginBottom: space.md,
     marginHorizontal: space.lg,
     gap: space.sm,
   },
   titleContainer: {
-    flexDirection: 'row',
     alignItems: 'center',
+    flexDirection: 'row',
     justifyContent: 'space-between',
-    paddingBottom: space.sm,
+    paddingBottom: space.xs,
   },
   title: {
     color: baseColors.text,
     fontSize: textTheme.size.xl,
     fontFamily: textTheme.family.bold,
+  },
+  actions: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: space.sm,
   },
   tagLine: {
     color: baseColors.textSoft,

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -1,0 +1,428 @@
+import { baseColors } from '@/theme/colors';
+import { radius } from '@/theme/radius';
+import { space } from '@/theme/space';
+import { text as textTheme } from '@/theme/type';
+import { Check, ChevronDown } from 'lucide-react-native';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Animated,
+  Easing,
+  Modal,
+  Pressable,
+  type LayoutChangeEvent,
+  ScrollView,
+  StyleSheet,
+  View,
+  type ViewStyle,
+} from 'react-native';
+
+import { Text } from './Text';
+
+export type SelectOption = {
+  label: string;
+  value: string;
+  description?: string;
+};
+
+type SelectProps = {
+  options: SelectOption[];
+  value?: string;
+  defaultValue?: string;
+  placeholder?: string;
+  onChange?: (value: string) => void;
+  color?: string;
+  style?: ViewStyle;
+  label?: string;
+  required?: boolean;
+  sheetTitle?: string;
+  size?: 'compact' | 'default' | 'header';
+  disabled?: boolean;
+};
+
+export function Select({
+  options,
+  value,
+  defaultValue,
+  placeholder = 'Select an option',
+  onChange,
+  color = baseColors.text,
+  style,
+  label,
+  required,
+  sheetTitle,
+  size = 'default',
+  disabled = false,
+}: SelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const [sheetHeight, setSheetHeight] = useState(0);
+  const selectedValue = value ?? internalValue;
+  const selectedOption = useMemo(
+    () => options.find((option) => option.value === selectedValue) ?? null,
+    [options, selectedValue],
+  );
+  const chevronRotation = useRef(new Animated.Value(0)).current;
+  const drawerProgress = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(chevronRotation, {
+      toValue: isOpen ? 1 : 0,
+      duration: 180,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [chevronRotation, isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsMounted(true);
+      Animated.timing(drawerProgress, {
+        toValue: 1,
+        duration: 260,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+      return;
+    }
+
+    if (!isMounted) {
+      drawerProgress.setValue(0);
+      return;
+    }
+
+    Animated.timing(drawerProgress, {
+      toValue: 0,
+      duration: 220,
+      easing: Easing.in(Easing.cubic),
+      useNativeDriver: true,
+    }).start(({ finished }) => {
+      if (finished) {
+        setIsMounted(false);
+      }
+    });
+  }, [drawerProgress, isMounted, isOpen]);
+
+  const chevronAnimatedStyle = useMemo(
+    () => ({
+      transform: [
+        {
+          rotate: chevronRotation.interpolate({
+            inputRange: [0, 1],
+            outputRange: ['0deg', '180deg'],
+          }),
+        },
+      ],
+    }),
+    [chevronRotation],
+  );
+
+  const drawerAnimatedStyle = useMemo(
+    () => ({
+      opacity: drawerProgress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, 1],
+      }),
+      transform: [
+        {
+          translateY: drawerProgress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [Math.max(sheetHeight + 32, 320), 0],
+          }),
+        },
+      ],
+    }),
+    [drawerProgress, sheetHeight],
+  );
+
+  const overlayAnimatedStyle = useMemo(
+    () => ({
+      opacity: drawerProgress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, 1],
+      }),
+    }),
+    [drawerProgress],
+  );
+
+  function handleSelect(nextValue: string) {
+    if (value === undefined) {
+      setInternalValue(nextValue);
+    }
+
+    onChange?.(nextValue);
+    setIsOpen(false);
+  }
+
+  const triggerTextColor = selectedOption ? baseColors.text : baseColors.textSoft;
+  const isCompactTrigger = size === 'compact' || size === 'header';
+
+  function handleSheetLayout(event: LayoutChangeEvent) {
+    setSheetHeight(event.nativeEvent.layout.height);
+  }
+
+  return (
+    <View style={style}>
+      {label ? (
+        <Text style={styles.fieldLabel}>
+          {label}
+          {required ? ' *' : ''}
+        </Text>
+      ) : null}
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ disabled, expanded: isOpen }}
+        disabled={disabled}
+        onPress={() => setIsOpen(true)}
+        style={({ pressed }) => [
+          styles.trigger,
+          size === 'compact' ? styles.triggerCompact : null,
+          size === 'header' ? styles.triggerHeader : null,
+          {
+            borderColor: isOpen ? color : 'rgba(255, 255, 255, 0.08)',
+          },
+          pressed && !disabled ? styles.triggerPressed : null,
+          disabled ? styles.triggerDisabled : null,
+        ]}
+      >
+        <Text
+          numberOfLines={1}
+          style={[
+            styles.triggerText,
+            isCompactTrigger ? styles.triggerTextCompact : null,
+            size === 'header' ? styles.triggerTextHeader : null,
+            { color: triggerTextColor },
+          ]}
+        >
+          {selectedOption?.label ?? placeholder}
+        </Text>
+        <Animated.View style={chevronAnimatedStyle}>
+          <ChevronDown
+            color={baseColors.text}
+            size={size === 'header' ? 16 : 20}
+            strokeWidth={2.2}
+          />
+        </Animated.View>
+      </Pressable>
+
+      <Modal onRequestClose={() => setIsOpen(false)} transparent visible={isMounted}>
+        <View style={styles.modalRoot}>
+          <Animated.View style={[styles.overlay, overlayAnimatedStyle]}>
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => setIsOpen(false)}
+              style={StyleSheet.absoluteFillObject}
+            />
+          </Animated.View>
+
+          <Animated.View
+            onLayout={handleSheetLayout}
+            style={[styles.sheet, drawerAnimatedStyle]}
+          >
+            <View style={styles.sheetHandle} />
+
+            <View style={styles.sheetHeader}>
+              <Text style={styles.sheetTitle}>
+                {sheetTitle ?? label ?? placeholder}
+              </Text>
+            </View>
+
+            <ScrollView
+              bounces={false}
+              contentContainerStyle={styles.optionList}
+              showsVerticalScrollIndicator={false}
+            >
+              {options.map((option) => {
+                const isSelected = option.value === selectedValue;
+
+                return (
+                  <Pressable
+                    accessibilityRole="button"
+                    key={option.value}
+                    onPress={() => handleSelect(option.value)}
+                    style={({ pressed }) => [
+                      styles.optionRow,
+                      isSelected
+                        ? {
+                            backgroundColor: 'rgba(255, 255, 255, 0.07)',
+                            borderColor: color,
+                          }
+                        : null,
+                      pressed ? styles.optionRowPressed : null,
+                    ]}
+                  >
+                    <View style={styles.optionTextWrap}>
+                      <Text
+                        style={[
+                          styles.optionLabel,
+                          isSelected ? { color } : null,
+                        ]}
+                      >
+                        {option.label}
+                      </Text>
+                      {option.description ? (
+                        <Text style={styles.optionDescription}>
+                          {option.description}
+                        </Text>
+                      ) : null}
+                    </View>
+
+                    <View
+                      style={[
+                        styles.optionIndicator,
+                        isSelected
+                          ? { backgroundColor: color, borderColor: color }
+                          : null,
+                      ]}
+                    >
+                      {isSelected ? (
+                        <Check color={baseColors.bg} size={14} strokeWidth={3} />
+                      ) : null}
+                    </View>
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+          </Animated.View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  fieldLabel: {
+    color: baseColors.text,
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.lg,
+    lineHeight: textTheme.lineHeight.lg,
+    marginBottom: space.sm,
+  },
+  trigger: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    borderCurve: 'continuous',
+    borderRadius: radius.xl,
+    borderWidth: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    minHeight: 60,
+    paddingHorizontal: space.xl,
+  },
+  triggerCompact: {
+    minHeight: 52,
+    paddingHorizontal: space.lg,
+  },
+  triggerHeader: {
+    backgroundColor: 'rgba(255, 255, 255, 0.06)',
+    borderRadius: radius.full,
+    minHeight: 34,
+    maxWidth: 132,
+    minWidth: 88,
+    paddingHorizontal: space.md,
+  },
+  triggerPressed: {
+    opacity: 0.92,
+  },
+  triggerDisabled: {
+    opacity: 0.5,
+  },
+  triggerText: {
+    flex: 1,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.lg,
+    lineHeight: textTheme.lineHeight.lg,
+    marginRight: space.md,
+  },
+  triggerTextCompact: {
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+    marginRight: space.sm,
+  },
+  triggerTextHeader: {
+    fontFamily: textTheme.family.semiBold,
+    textAlign: 'center',
+  },
+  modalRoot: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  },
+  sheet: {
+    backgroundColor: '#232220',
+    borderTopLeftRadius: 30,
+    borderTopRightRadius: 30,
+    maxHeight: '72%',
+    paddingBottom: space.xl,
+    paddingHorizontal: space.lg,
+    paddingTop: space.md,
+  },
+  sheetHandle: {
+    alignSelf: 'center',
+    backgroundColor: 'rgba(245, 240, 236, 0.16)',
+    borderRadius: radius.full,
+    height: 5,
+    marginBottom: space.md,
+    width: 52,
+  },
+  sheetHeader: {
+    alignItems: 'center',
+    marginBottom: space.md,
+  },
+  sheetTitle: {
+    color: baseColors.text,
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.lg,
+    lineHeight: textTheme.lineHeight.lg,
+    textAlign: 'center',
+  },
+  optionList: {
+    gap: space.sm,
+    paddingBottom: space.md,
+  },
+  optionRow: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.03)',
+    borderColor: 'rgba(255, 255, 255, 0.06)',
+    borderCurve: 'continuous',
+    borderRadius: 22,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: space.md,
+    justifyContent: 'space-between',
+    paddingHorizontal: space.lg,
+    paddingVertical: space.md + space.xxs,
+  },
+  optionRowPressed: {
+    opacity: 0.88,
+  },
+  optionTextWrap: {
+    flex: 1,
+    gap: space.xs,
+  },
+  optionLabel: {
+    color: baseColors.text,
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.md,
+    lineHeight: textTheme.lineHeight.md,
+  },
+  optionDescription: {
+    color: baseColors.textSoft,
+    fontFamily: textTheme.family.regular,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  optionIndicator: {
+    alignItems: 'center',
+    borderColor: 'rgba(255, 255, 255, 0.12)',
+    borderRadius: radius.full,
+    borderWidth: 1,
+    height: 24,
+    justifyContent: 'center',
+    width: 24,
+  },
+});

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -11,7 +11,17 @@ import {
   StyleSheet,
   View,
   type ViewStyle,
+  useWindowDimensions,
 } from 'react-native';
+import Animated, {
+  Easing,
+  interpolate,
+  runOnJS,
+  type SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 
 import { Text } from './Text';
 
@@ -35,6 +45,73 @@ type SelectProps = {
   disabled?: boolean;
 };
 
+function animateDrawerOpen(drawerProgress: SharedValue<number>) {
+  drawerProgress.value = 0;
+  drawerProgress.value = withTiming(1, {
+    duration: 260,
+    easing: Easing.out(Easing.cubic),
+  });
+}
+
+function animateDrawerClose(
+  drawerProgress: SharedValue<number>,
+  onCloseComplete: () => void,
+) {
+  drawerProgress.value = withTiming(
+    0,
+    {
+      duration: 220,
+      easing: Easing.in(Easing.cubic),
+    },
+    (finished) => {
+      if (finished) {
+        runOnJS(onCloseComplete)();
+      }
+    },
+  );
+}
+
+function useDrawerAnimation(
+  windowHeight: number,
+  onCloseComplete: () => void,
+) {
+  const drawerProgress = useSharedValue(0);
+
+  const backdropAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(drawerProgress.value, [0, 1], [0, 1]),
+  }));
+
+  const sheetAnimatedStyle = useAnimatedStyle(
+    () => ({
+      transform: [
+        {
+          translateY: interpolate(
+            drawerProgress.value,
+            [0, 1],
+            [windowHeight, 0],
+          ),
+        },
+      ],
+    }),
+    [windowHeight],
+  );
+
+  function openDrawer() {
+    animateDrawerOpen(drawerProgress);
+  }
+
+  function closeDrawer() {
+    animateDrawerClose(drawerProgress, onCloseComplete);
+  }
+
+  return {
+    backdropAnimatedStyle,
+    sheetAnimatedStyle,
+    openDrawer,
+    closeDrawer,
+  };
+}
+
 export function Select({
   options,
   value,
@@ -49,15 +126,18 @@ export function Select({
   disabled = false,
 }: SelectProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const { height: windowHeight } = useWindowDimensions();
   const selectedValue = value;
   const selectedOption = useMemo(
     () => options.find((option) => option.value === selectedValue) ?? null,
     [options, selectedValue],
   );
+  const { backdropAnimatedStyle, sheetAnimatedStyle, openDrawer, closeDrawer } =
+    useDrawerAnimation(windowHeight, () => setIsOpen(false));
 
   function handleSelect(nextValue: string) {
     onChange?.(nextValue);
-    setIsOpen(false);
+    closeDrawer();
   }
 
   const triggerTextColor = selectedOption ? baseColors.text : baseColors.textSoft;
@@ -76,7 +156,14 @@ export function Select({
         accessibilityRole="button"
         accessibilityState={{ disabled, expanded: isOpen }}
         disabled={disabled}
-        onPress={() => setIsOpen(true)}
+        onPress={() => {
+          if (isOpen) {
+            return;
+          }
+
+          setIsOpen(true);
+          openDrawer();
+        }}
         style={({ pressed }) => [
           styles.trigger,
           size === 'compact' ? styles.triggerCompact : null,
@@ -113,21 +200,20 @@ export function Select({
       </Pressable>
 
       <Modal
-        animationType="slide"
-        onRequestClose={() => setIsOpen(false)}
+        onRequestClose={closeDrawer}
         transparent
         visible={isOpen}
       >
         <View style={styles.modalRoot}>
-          <View style={styles.overlay}>
+          <Animated.View style={[styles.overlay, backdropAnimatedStyle]}>
             <Pressable
               accessibilityRole="button"
-              onPress={() => setIsOpen(false)}
+              onPress={closeDrawer}
               style={StyleSheet.absoluteFillObject}
             />
-          </View>
+          </Animated.View>
 
-          <View style={styles.sheet}>
+          <Animated.View style={[styles.sheet, sheetAnimatedStyle]}>
             <View style={styles.sheetHandle} />
 
             <View style={styles.sheetHeader}>
@@ -192,7 +278,7 @@ export function Select({
                 );
               })}
             </ScrollView>
-          </View>
+          </Animated.View>
         </View>
       </Modal>
     </View>

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -3,13 +3,10 @@ import { radius } from '@/theme/radius';
 import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
 import { Check, ChevronDown } from 'lucide-react-native';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
-  Animated,
-  Easing,
   Modal,
   Pressable,
-  type LayoutChangeEvent,
   ScrollView,
   StyleSheet,
   View,
@@ -27,7 +24,6 @@ export type SelectOption = {
 type SelectProps = {
   options: SelectOption[];
   value?: string;
-  defaultValue?: string;
   placeholder?: string;
   onChange?: (value: string) => void;
   color?: string;
@@ -42,7 +38,6 @@ type SelectProps = {
 export function Select({
   options,
   value,
-  defaultValue,
   placeholder = 'Select an option',
   onChange,
   color = baseColors.text,
@@ -54,112 +49,19 @@ export function Select({
   disabled = false,
 }: SelectProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
-  const [internalValue, setInternalValue] = useState(defaultValue);
-  const [sheetHeight, setSheetHeight] = useState(0);
-  const selectedValue = value ?? internalValue;
+  const selectedValue = value;
   const selectedOption = useMemo(
     () => options.find((option) => option.value === selectedValue) ?? null,
     [options, selectedValue],
   );
-  const chevronRotation = useRef(new Animated.Value(0)).current;
-  const drawerProgress = useRef(new Animated.Value(0)).current;
-
-  useEffect(() => {
-    Animated.timing(chevronRotation, {
-      toValue: isOpen ? 1 : 0,
-      duration: 180,
-      easing: Easing.out(Easing.cubic),
-      useNativeDriver: true,
-    }).start();
-  }, [chevronRotation, isOpen]);
-
-  useEffect(() => {
-    if (isOpen) {
-      setIsMounted(true);
-      Animated.timing(drawerProgress, {
-        toValue: 1,
-        duration: 260,
-        easing: Easing.out(Easing.cubic),
-        useNativeDriver: true,
-      }).start();
-      return;
-    }
-
-    if (!isMounted) {
-      drawerProgress.setValue(0);
-      return;
-    }
-
-    Animated.timing(drawerProgress, {
-      toValue: 0,
-      duration: 220,
-      easing: Easing.in(Easing.cubic),
-      useNativeDriver: true,
-    }).start(({ finished }) => {
-      if (finished) {
-        setIsMounted(false);
-      }
-    });
-  }, [drawerProgress, isMounted, isOpen]);
-
-  const chevronAnimatedStyle = useMemo(
-    () => ({
-      transform: [
-        {
-          rotate: chevronRotation.interpolate({
-            inputRange: [0, 1],
-            outputRange: ['0deg', '180deg'],
-          }),
-        },
-      ],
-    }),
-    [chevronRotation],
-  );
-
-  const drawerAnimatedStyle = useMemo(
-    () => ({
-      opacity: drawerProgress.interpolate({
-        inputRange: [0, 1],
-        outputRange: [0, 1],
-      }),
-      transform: [
-        {
-          translateY: drawerProgress.interpolate({
-            inputRange: [0, 1],
-            outputRange: [Math.max(sheetHeight + 32, 320), 0],
-          }),
-        },
-      ],
-    }),
-    [drawerProgress, sheetHeight],
-  );
-
-  const overlayAnimatedStyle = useMemo(
-    () => ({
-      opacity: drawerProgress.interpolate({
-        inputRange: [0, 1],
-        outputRange: [0, 1],
-      }),
-    }),
-    [drawerProgress],
-  );
 
   function handleSelect(nextValue: string) {
-    if (value === undefined) {
-      setInternalValue(nextValue);
-    }
-
     onChange?.(nextValue);
     setIsOpen(false);
   }
 
   const triggerTextColor = selectedOption ? baseColors.text : baseColors.textSoft;
   const isCompactTrigger = size === 'compact' || size === 'header';
-
-  function handleSheetLayout(event: LayoutChangeEvent) {
-    setSheetHeight(event.nativeEvent.layout.height);
-  }
 
   return (
     <View style={style}>
@@ -197,29 +99,35 @@ export function Select({
         >
           {selectedOption?.label ?? placeholder}
         </Text>
-        <Animated.View style={chevronAnimatedStyle}>
+        <View
+          style={{
+            transform: [{ rotate: isOpen ? '180deg' : '0deg' }],
+          }}
+        >
           <ChevronDown
             color={baseColors.text}
             size={size === 'header' ? 16 : 20}
             strokeWidth={2.2}
           />
-        </Animated.View>
+        </View>
       </Pressable>
 
-      <Modal onRequestClose={() => setIsOpen(false)} transparent visible={isMounted}>
+      <Modal
+        animationType="slide"
+        onRequestClose={() => setIsOpen(false)}
+        transparent
+        visible={isOpen}
+      >
         <View style={styles.modalRoot}>
-          <Animated.View style={[styles.overlay, overlayAnimatedStyle]}>
+          <View style={styles.overlay}>
             <Pressable
               accessibilityRole="button"
               onPress={() => setIsOpen(false)}
               style={StyleSheet.absoluteFillObject}
             />
-          </Animated.View>
+          </View>
 
-          <Animated.View
-            onLayout={handleSheetLayout}
-            style={[styles.sheet, drawerAnimatedStyle]}
-          >
+          <View style={styles.sheet}>
             <View style={styles.sheetHandle} />
 
             <View style={styles.sheetHeader}>
@@ -284,7 +192,7 @@ export function Select({
                 );
               })}
             </ScrollView>
-          </Animated.View>
+          </View>
         </View>
       </Modal>
     </View>

--- a/hooks/useActiveGroup.ts
+++ b/hooks/useActiveGroup.ts
@@ -1,0 +1,74 @@
+import { listGroupsForCurrentUser } from '@/services/groups';
+import { useActiveGroupStore } from '@/stores/useActiveGroupStore';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo } from 'react';
+
+export function useActiveGroup() {
+  const activeGroupId = useActiveGroupStore((state) => state.activeGroupId);
+  const hasHydrated = useActiveGroupStore((state) => state.hasHydrated);
+  const hydrate = useActiveGroupStore((state) => state.hydrate);
+  const setActiveGroupId = useActiveGroupStore((state) => state.setActiveGroupId);
+
+  useEffect(() => {
+    void hydrate();
+  }, [hydrate]);
+
+  const groupsQuery = useQuery({
+    queryKey: ['groups', 'current-user'],
+    queryFn: listGroupsForCurrentUser,
+    staleTime: 5 * 60 * 1000,
+  });
+  const groups = useMemo(() => groupsQuery.data ?? [], [groupsQuery.data]);
+
+  useEffect(() => {
+    if (!hasHydrated || groupsQuery.isPending) {
+      return;
+    }
+
+    if (groups.length === 0) {
+      if (activeGroupId !== null) {
+        setActiveGroupId(null);
+      }
+
+      return;
+    }
+
+    const hasStoredGroup = groups.some((group) => group.id === activeGroupId);
+
+    if (hasStoredGroup) {
+      return;
+    }
+
+    const fallbackGroupId = groups[0]?.id ?? null;
+
+    if (fallbackGroupId !== activeGroupId) {
+      setActiveGroupId(fallbackGroupId);
+    }
+  }, [
+    activeGroupId,
+    groups,
+    groupsQuery.isPending,
+    hasHydrated,
+    setActiveGroupId,
+  ]);
+
+  const activeGroup = useMemo(
+    () => groups.find((group) => group.id === activeGroupId) ?? groups[0] ?? null,
+    [activeGroupId, groups],
+  );
+  const errorMessage =
+    groupsQuery.error instanceof Error
+      ? groupsQuery.error.message
+      : groupsQuery.error
+        ? 'Failed to load your groups.'
+        : null;
+
+  return {
+    groups,
+    activeGroup,
+    activeGroupId: activeGroup?.id ?? null,
+    isLoading: !hasHydrated || groupsQuery.isPending,
+    errorMessage,
+    setActiveGroupId,
+  };
+}

--- a/hooks/useEvents.ts
+++ b/hooks/useEvents.ts
@@ -30,10 +30,15 @@ export function useEventDetailQuery(
   eventId?: string,
   groupId?: string | null,
 ) {
+  const resolvedGroupId = groupId ?? null;
+
   return useQuery({
-    queryKey: eventKeys.detail(eventId ?? 'missing', groupId ?? null),
+    queryKey: eventKeys.detail(eventId ?? 'missing', resolvedGroupId),
+    enabled: Boolean(eventId && resolvedGroupId),
     queryFn: () =>
-      eventId ? getEventById(eventId, groupId ?? null) : Promise.resolve(null),
+      eventId && resolvedGroupId
+        ? getEventById(eventId, resolvedGroupId)
+        : Promise.resolve(null),
   });
 }
 

--- a/hooks/useEvents.ts
+++ b/hooks/useEvents.ts
@@ -1,10 +1,9 @@
 import {
   createEvent,
   getEventById,
-  listEventsForCurrentUser,
+  listEventsForGroup,
 } from '@/services/events';
 import {
-  skipToken,
   useMutation,
   useQuery,
   useQueryClient,
@@ -13,22 +12,28 @@ import {
 export const eventKeys = {
   all: ['events'] as const,
   lists: () => [...eventKeys.all, 'list'] as const,
-  list: () => [...eventKeys.lists(), 'current-user'] as const,
+  list: (groupId: string | null) =>
+    [...eventKeys.lists(), groupId ?? 'no-group'] as const,
   details: () => [...eventKeys.all, 'detail'] as const,
-  detail: (eventId: string) => [...eventKeys.details(), eventId] as const,
+  detail: (eventId: string, groupId: string | null) =>
+    [...eventKeys.details(), eventId, groupId ?? 'no-group'] as const,
 };
 
-export function useEventsQuery() {
+export function useEventsQuery(groupId?: string | null) {
   return useQuery({
-    queryKey: eventKeys.list(),
-    queryFn: listEventsForCurrentUser,
+    queryKey: eventKeys.list(groupId ?? null),
+    queryFn: () => (groupId ? listEventsForGroup(groupId) : Promise.resolve([])),
   });
 }
 
-export function useEventDetailQuery(eventId?: string) {
+export function useEventDetailQuery(
+  eventId?: string,
+  groupId?: string | null,
+) {
   return useQuery({
-    queryKey: eventKeys.detail(eventId ?? 'missing'),
-    queryFn: eventId ? () => getEventById(eventId) : skipToken,
+    queryKey: eventKeys.detail(eventId ?? 'missing', groupId ?? null),
+    queryFn: () =>
+      eventId ? getEventById(eventId, groupId ?? null) : Promise.resolve(null),
   });
 }
 

--- a/hooks/useMoments.ts
+++ b/hooks/useMoments.ts
@@ -1,34 +1,38 @@
 import {
   createMoment,
   getMomentById,
-  listMomentsForCurrentUser,
+  listMomentsForGroup,
 } from '@/services/moments';
-import {
-  skipToken,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 export const momentKeys = {
   all: ['moments'] as const,
   lists: () => [...momentKeys.all, 'list'] as const,
-  list: () => [...momentKeys.lists(), 'current-user'] as const,
+  list: (groupId: string | null) =>
+    [...momentKeys.lists(), groupId ?? 'no-group'] as const,
   details: () => [...momentKeys.all, 'detail'] as const,
-  detail: (momentId: string) => [...momentKeys.details(), momentId] as const,
+  detail: (momentId: string, groupId: string | null) =>
+    [...momentKeys.details(), momentId, groupId ?? 'no-group'] as const,
 };
 
-export function useMomentsQuery() {
+export function useMomentsQuery(groupId?: string | null) {
   return useQuery({
-    queryKey: momentKeys.list(),
-    queryFn: listMomentsForCurrentUser,
+    queryKey: momentKeys.list(groupId ?? null),
+    queryFn: () =>
+      groupId ? listMomentsForGroup(groupId) : Promise.resolve([]),
   });
 }
 
-export function useMomentDetailQuery(momentId?: string) {
+export function useMomentDetailQuery(
+  momentId?: string,
+  groupId?: string | null,
+) {
   return useQuery({
-    queryKey: momentKeys.detail(momentId ?? 'missing'),
-    queryFn: momentId ? () => getMomentById(momentId) : skipToken,
+    queryKey: momentKeys.detail(momentId ?? 'missing', groupId ?? null),
+    queryFn: () =>
+      momentId
+        ? getMomentById(momentId, groupId ?? null)
+        : Promise.resolve(null),
   });
 }
 

--- a/hooks/useMoments.ts
+++ b/hooks/useMoments.ts
@@ -27,11 +27,14 @@ export function useMomentDetailQuery(
   momentId?: string,
   groupId?: string | null,
 ) {
+  const resolvedGroupId = groupId ?? null;
+
   return useQuery({
-    queryKey: momentKeys.detail(momentId ?? 'missing', groupId ?? null),
+    queryKey: momentKeys.detail(momentId ?? 'missing', resolvedGroupId),
+    enabled: Boolean(momentId && resolvedGroupId),
     queryFn: () =>
-      momentId
-        ? getMomentById(momentId, groupId ?? null)
+      momentId && resolvedGroupId
+        ? getMomentById(momentId, resolvedGroupId)
         : Promise.resolve(null),
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,8 @@
         "react-native-url-polyfill": "^3.0.0",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1",
-        "zod": "^4.3.6"
+        "zod": "^4.3.6",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@types/react": "~19.1.0",
@@ -13429,6 +13430,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "react-native-url-polyfill": "^3.0.0",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/services/events.ts
+++ b/services/events.ts
@@ -5,6 +5,7 @@ export type EventPhotoInput = {
 };
 
 export type CreateEventInput = {
+  groupId: string;
   title: string;
   occurredAt: Date;
   location: string;
@@ -67,41 +68,17 @@ async function getCurrentUserId(): Promise<string | null> {
   return user?.id ?? null;
 }
 
-async function getPersonalGroupIdForUser(userId: string): Promise<string> {
-  const { data: groups, error } = await supabase
-    .from('groups')
-    .select('id, name, group_kind')
-    .eq('personal_owner_user_id', userId);
-
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  const personalGroup =
-    groups?.find((group) => group.group_kind === 'personal') ??
-    groups?.find((group) => group.name?.toLowerCase() === 'personal') ??
-    groups?.[0];
-
-  if (!personalGroup?.id) {
-    throw new Error(
-      'No group found for this user yet. The personal group needs to exist before creating events.',
-    );
-  }
-
-  return personalGroup.id;
-}
-
-export async function listEventsForCurrentUser(): Promise<EventListItem[]> {
+export async function listEventsForGroup(groupId: string): Promise<EventListItem[]> {
   const userId = await getCurrentUserId();
 
-  if (!userId) {
+  if (!userId || !groupId) {
     return [];
   }
 
   const { data: events, error } = await supabase
     .from('events')
     .select('id, title, occurred_on, location_text, mood, created_at')
-    .eq('created_by', userId)
+    .eq('group_id', groupId)
     .order('occurred_on', { ascending: false })
     .order('created_at', { ascending: false });
 
@@ -158,11 +135,14 @@ export async function createEvent(input: CreateEventInput): Promise<string> {
     throw new Error('You must be signed in to create an event.');
   }
 
-  const groupId = await getPersonalGroupIdForUser(userId);
+  if (!input.groupId) {
+    throw new Error('A group must be selected before creating an event.');
+  }
+
   const { data: insertedEvent, error: eventError } = await supabase
     .from('events')
     .insert({
-      group_id: groupId,
+      group_id: input.groupId,
       created_by: userId,
       title: input.title.trim(),
       occurred_on: input.occurredAt.toISOString().slice(0, 10),
@@ -193,7 +173,7 @@ export async function createEvent(input: CreateEventInput): Promise<string> {
     .from('photos')
     .insert(
       persistedPhotoCandidates.map((photo) => ({
-        group_id: groupId,
+        group_id: input.groupId,
         uploaded_by: userId,
         storage_path: photo.storagePath!,
         caption: null,
@@ -212,7 +192,7 @@ export async function createEvent(input: CreateEventInput): Promise<string> {
 
   const { error: linksError } = await supabase.from('event_photos').insert(
     insertedPhotos.map((photo, index) => ({
-      group_id: groupId,
+      group_id: input.groupId,
       event_id: insertedEvent.id,
       photo_id: photo.id,
       sort_order: index,
@@ -228,6 +208,7 @@ export async function createEvent(input: CreateEventInput): Promise<string> {
 
 export async function getEventById(
   eventId: string,
+  groupId?: string | null,
 ): Promise<EventDetail | null> {
   const userId = await getCurrentUserId();
 
@@ -235,12 +216,16 @@ export async function getEventById(
     return null;
   }
 
-  const { data: event, error } = await supabase
+  let query = supabase
     .from('events')
     .select('id, title, occurred_on, location_text, mood, notes')
-    .eq('id', eventId)
-    .eq('created_by', userId)
-    .maybeSingle();
+    .eq('id', eventId);
+
+  if (groupId) {
+    query = query.eq('group_id', groupId);
+  }
+
+  const { data: event, error } = await query.maybeSingle();
 
   if (error) {
     throw new Error(error.message);

--- a/services/events.ts
+++ b/services/events.ts
@@ -208,7 +208,7 @@ export async function createEvent(input: CreateEventInput): Promise<string> {
 
 export async function getEventById(
   eventId: string,
-  groupId?: string | null,
+  groupId: string,
 ): Promise<EventDetail | null> {
   const userId = await getCurrentUserId();
 
@@ -216,16 +216,12 @@ export async function getEventById(
     return null;
   }
 
-  let query = supabase
+  const { data: event, error } = await supabase
     .from('events')
     .select('id, title, occurred_on, location_text, mood, notes')
-    .eq('id', eventId);
-
-  if (groupId) {
-    query = query.eq('group_id', groupId);
-  }
-
-  const { data: event, error } = await query.maybeSingle();
+    .eq('id', eventId)
+    .eq('group_id', groupId)
+    .maybeSingle();
 
   if (error) {
     throw new Error(error.message);
@@ -239,6 +235,7 @@ export async function getEventById(
     .from('event_photos')
     .select('sort_order, photos(storage_path)')
     .eq('event_id', eventId)
+    .eq('group_id', groupId)
     .order('sort_order', { ascending: true })
     .order('created_at', { ascending: true });
 

--- a/services/groups.ts
+++ b/services/groups.ts
@@ -1,0 +1,124 @@
+import { supabase } from '@/lib/supabase';
+
+type GroupRow = {
+  id?: string | null;
+  name?: string | null;
+  group_kind?: string | null;
+  personal_owner_user_id?: string | null;
+  created_at?: string | null;
+};
+
+type GroupMembershipRow = {
+  role?: string | null;
+  joined_at?: string | null;
+  groups?: GroupRow | GroupRow[] | null;
+};
+
+type ResolvedGroupRow = {
+  id: string;
+  name: string;
+  group_kind?: string | null;
+  personal_owner_user_id?: string | null;
+  created_at?: string | null;
+};
+
+export type UserGroup = {
+  id: string;
+  name: string;
+  groupKind: string | null;
+  personalOwnerUserId: string | null;
+  role: string | null;
+  joinedAt: string | null;
+  createdAt: string | null;
+};
+
+async function getCurrentUserId(): Promise<string | null> {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return user?.id ?? null;
+}
+
+function extractGroup(row: GroupMembershipRow): ResolvedGroupRow | null {
+  const group = Array.isArray(row.groups) ? row.groups[0] : row.groups;
+
+  if (!group?.id || !group.name) {
+    return null;
+  }
+
+  return {
+    id: group.id,
+    name: group.name,
+    group_kind: group.group_kind ?? null,
+    personal_owner_user_id: group.personal_owner_user_id ?? null,
+    created_at: group.created_at ?? null,
+  };
+}
+
+function compareUserGroups(left: UserGroup, right: UserGroup): number {
+  const leftIsPersonal = left.groupKind === 'personal';
+  const rightIsPersonal = right.groupKind === 'personal';
+
+  if (leftIsPersonal !== rightIsPersonal) {
+    return leftIsPersonal ? -1 : 1;
+  }
+
+  const leftTimestamp = left.joinedAt ?? left.createdAt ?? '';
+  const rightTimestamp = right.joinedAt ?? right.createdAt ?? '';
+
+  if (leftTimestamp !== rightTimestamp) {
+    return leftTimestamp.localeCompare(rightTimestamp);
+  }
+
+  return left.name.localeCompare(right.name);
+}
+
+export async function listGroupsForUser(userId: string): Promise<UserGroup[]> {
+  const { data, error } = await supabase
+    .from('group_members')
+    .select(
+      'role, joined_at, groups!inner(id, name, group_kind, personal_owner_user_id, created_at)',
+    )
+    .eq('user_id', userId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return ((data ?? []) as GroupMembershipRow[])
+    .map((row) => {
+      const group = extractGroup(row);
+
+      if (!group) {
+        return null;
+      }
+
+      return {
+        id: group.id,
+        name: group.name,
+        groupKind: group.group_kind ?? null,
+        personalOwnerUserId: group.personal_owner_user_id ?? null,
+        role: row.role ?? null,
+        joinedAt: row.joined_at ?? null,
+        createdAt: group.created_at ?? null,
+      } satisfies UserGroup;
+    })
+    .filter((group): group is UserGroup => Boolean(group))
+    .sort(compareUserGroups);
+}
+
+export async function listGroupsForCurrentUser(): Promise<UserGroup[]> {
+  const userId = await getCurrentUserId();
+
+  if (!userId) {
+    return [];
+  }
+
+  return listGroupsForUser(userId);
+}

--- a/services/moments.ts
+++ b/services/moments.ts
@@ -200,7 +200,7 @@ export async function createMoment(input: CreateMomentInput): Promise<string> {
 
 export async function getMomentById(
   momentId: string,
-  groupId?: string | null,
+  groupId: string,
 ): Promise<MomentDetail | null> {
   const userId = await getCurrentUserId();
 
@@ -208,16 +208,12 @@ export async function getMomentById(
     return null;
   }
 
-  let query = supabase
+  const { data: moment, error: momentError } = await supabase
     .from('moments')
     .select('id, title, description, category, occurred_on')
-    .eq('id', momentId);
-
-  if (groupId) {
-    query = query.eq('group_id', groupId);
-  }
-
-  const { data: moment, error: momentError } = await query.maybeSingle();
+    .eq('id', momentId)
+    .eq('group_id', groupId)
+    .maybeSingle();
 
   if (momentError) {
     throw new Error(momentError.message);
@@ -231,6 +227,7 @@ export async function getMomentById(
     .from('moment_photos')
     .select('sort_order, photos(storage_path)')
     .eq('moment_id', momentId)
+    .eq('group_id', groupId)
     .order('sort_order', { ascending: true });
 
   if (linksError) {

--- a/services/moments.ts
+++ b/services/moments.ts
@@ -5,6 +5,7 @@ export type MomentPhotoInput = {
 };
 
 export type CreateMomentInput = {
+  groupId: string;
   momentType: string;
   title: string;
   description: string;
@@ -59,41 +60,19 @@ async function getCurrentUserId(): Promise<string | null> {
   return user?.id ?? null;
 }
 
-async function getPersonalGroupIdForUser(userId: string): Promise<string> {
-  const { data: groups, error } = await supabase
-    .from('groups')
-    .select('id, name, group_kind')
-    .eq('personal_owner_user_id', userId);
-
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  const personalGroup =
-    groups?.find((group) => group.group_kind === 'personal') ??
-    groups?.find((group) => group.name?.toLowerCase() === 'personal') ??
-    groups?.[0];
-
-  if (!personalGroup?.id) {
-    throw new Error(
-      'No group found for this user yet. The personal group needs to exist before creating moments.',
-    );
-  }
-
-  return personalGroup.id;
-}
-
-export async function listMomentsForCurrentUser(): Promise<MomentListItem[]> {
+export async function listMomentsForGroup(
+  groupId: string,
+): Promise<MomentListItem[]> {
   const userId = await getCurrentUserId();
 
-  if (!userId) {
+  if (!userId || !groupId) {
     return [];
   }
 
   const { data: moments, error } = await supabase
     .from('moments')
     .select('id, title, description, category, occurred_on, created_at')
-    .eq('created_by', userId)
+    .eq('group_id', groupId)
     .order('occurred_on', { ascending: false })
     .order('created_at', { ascending: false });
 
@@ -149,11 +128,14 @@ export async function createMoment(input: CreateMomentInput): Promise<string> {
     throw new Error('You must be signed in to create a moment.');
   }
 
-  const groupId = await getPersonalGroupIdForUser(userId);
+  if (!input.groupId) {
+    throw new Error('A group must be selected before creating a moment.');
+  }
+
   const { data: insertedMoment, error: momentError } = await supabase
     .from('moments')
     .insert({
-      group_id: groupId,
+      group_id: input.groupId,
       created_by: userId,
       category: input.momentType,
       title: input.title.trim(),
@@ -183,7 +165,7 @@ export async function createMoment(input: CreateMomentInput): Promise<string> {
     .from('photos')
     .insert(
       persistedPhotoCandidates.map((photo) => ({
-        group_id: groupId,
+        group_id: input.groupId,
         uploaded_by: userId,
         storage_path: photo.storagePath!,
         caption: null,
@@ -202,7 +184,7 @@ export async function createMoment(input: CreateMomentInput): Promise<string> {
 
   const { error: linksError } = await supabase.from('moment_photos').insert(
     insertedPhotos.map((photo, index) => ({
-      group_id: groupId,
+      group_id: input.groupId,
       moment_id: insertedMoment.id,
       photo_id: photo.id,
       sort_order: index,
@@ -218,6 +200,7 @@ export async function createMoment(input: CreateMomentInput): Promise<string> {
 
 export async function getMomentById(
   momentId: string,
+  groupId?: string | null,
 ): Promise<MomentDetail | null> {
   const userId = await getCurrentUserId();
 
@@ -225,12 +208,16 @@ export async function getMomentById(
     return null;
   }
 
-  const { data: moment, error: momentError } = await supabase
+  let query = supabase
     .from('moments')
     .select('id, title, description, category, occurred_on')
-    .eq('id', momentId)
-    .eq('created_by', userId)
-    .maybeSingle();
+    .eq('id', momentId);
+
+  if (groupId) {
+    query = query.eq('group_id', groupId);
+  }
+
+  const { data: moment, error: momentError } = await query.maybeSingle();
 
   if (momentError) {
     throw new Error(momentError.message);

--- a/stores/useActiveGroupStore.ts
+++ b/stores/useActiveGroupStore.ts
@@ -1,0 +1,56 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+
+type ActiveGroupStore = {
+  activeGroupId: string | null;
+  hasHydrated: boolean;
+  hydrate: () => Promise<void>;
+  setActiveGroupId: (nextGroupId: string | null) => Promise<void>;
+};
+
+const ACTIVE_GROUP_STORAGE_KEY = 'memoir.active-group-id';
+
+let hydrationPromise: Promise<void> | null = null;
+
+export const useActiveGroupStore = create<ActiveGroupStore>()((set, get) => ({
+  activeGroupId: null,
+  hasHydrated: false,
+  hydrate: async () => {
+    if (get().hasHydrated) {
+      return;
+    }
+
+    if (hydrationPromise) {
+      return hydrationPromise;
+    }
+
+    hydrationPromise = AsyncStorage.getItem(ACTIVE_GROUP_STORAGE_KEY)
+      .then((storedGroupId) => {
+        set({
+          activeGroupId: storedGroupId,
+          hasHydrated: true,
+        });
+      })
+      .catch(() => {
+        set({
+          activeGroupId: null,
+          hasHydrated: true,
+        });
+      })
+      .finally(() => {
+        hydrationPromise = null;
+      });
+
+    return hydrationPromise;
+  },
+  setActiveGroupId: async (nextGroupId) => {
+    set({ activeGroupId: nextGroupId });
+
+    if (nextGroupId) {
+      await AsyncStorage.setItem(ACTIVE_GROUP_STORAGE_KEY, nextGroupId);
+      return;
+    }
+
+    await AsyncStorage.removeItem(ACTIVE_GROUP_STORAGE_KEY);
+  },
+}));


### PR DESCRIPTION
## Summary
This PR adds a global space concept to the app so a user can switch between their personal space and shared groups from the header, and have that selection apply everywhere.

The selected space is now treated as app-wide state instead of something each screen figures out independently. That means events and moments read from the active group, detail screens stay in the same scope, and new content is created in the currently selected space.

## What Changed
- Added a group membership service to load the spaces available to the signed-in user.
- Added a persisted Zustand store for `activeGroupId` so the selected space survives app restarts.
- Added `useActiveGroup()` to hydrate the saved selection, expose the available groups, and fall back safely if the previously selected group no longer exists.
- Updated events and moments services, queries, and screens to scope list, detail, and create flows by `groupId`.
- Added a compact header trigger next to the user icon for switching spaces globally.
- Added a bottom-drawer selector for space switching, with a static backdrop and sheet-only slide animation.
- Removed the per-form space picker from event and moment creation screens so creation follows the active global selection.

## Notes
- This PR is intentionally independent of the `profiles.group_ids` migration and continues to resolve memberships from `group_members`.
- The auth bootstrap cleanup and FAB shadow cleanup were merged separately to `main` and are not part of this review.

## Testing
- `npx tsc --noEmit`
- `npx -y react-doctor@latest . --verbose --diff`
- Manual verification:
  - switch between personal and shared spaces from the header
  - confirm events and moments lists update to the selected space
  - confirm detail screens stay scoped to the selected space
  - confirm new events and moments are created in the active space
  - confirm the picker opens as a bottom drawer and only the sheet animates
