### PR TITLE
Add edit and delete flows for moments

### DIFF
--- a/app/moments/[id].tsx
+++ b/app/moments/[id].tsx
@@ -1,33 +1,40 @@
+import {
+  AddImageField,
+  type SelectedImage,
+} from '@/components/ui/AddImageField';
 import Divider from '@/components/ui/Divider';
 import { Text } from '@/components/ui/Text';
 import { useActiveGroup } from '@/hooks/useActiveGroup';
-import { useMomentDetailQuery } from '@/hooks/useMoments';
+import {
+  useDeleteMomentMutation,
+  useMomentDetailQuery,
+  useUpdateMomentMutation,
+} from '@/hooks/useMoments';
+import { useImageUpload } from '@/hooks/useImageUpload';
+import { MAX_IMAGES_PER_UPLOAD } from '@/lib/images';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { radius } from '@/theme/radius';
 import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
 import { Image } from 'expo-image';
 import { router, useLocalSearchParams } from 'expo-router';
-import { CalendarDays, ChevronLeft } from 'lucide-react-native';
-import { useState } from 'react';
+import { CalendarDays, ChevronLeft, Ellipsis } from 'lucide-react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
+  Alert,
+  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
-  useWindowDimensions,
   View,
 } from 'react-native';
-
-const ITEM_WIDTH = 110;
-const COLUMNS = 3;
 
 const FALLBACK_COVER_IMAGE = require('../../assets/images/fallbackImage.png');
 
 function formatOccurredOn(dateValue: string): string {
   const date = new Date(dateValue);
+
   if (Number.isNaN(date.getTime())) {
     return dateValue;
   }
@@ -37,6 +44,18 @@ function formatOccurredOn(dateValue: string): string {
     day: 'numeric',
     year: 'numeric',
   });
+}
+
+function parseOccurredAt(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number);
+
+  if ([year, month, day].every((part) => Number.isFinite(part))) {
+    return new Date(year, month - 1, day);
+  }
+
+  const parsed = new Date(value);
+
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
 }
 
 function formatMomentType(value: string | null): string {
@@ -51,36 +70,295 @@ function formatMomentType(value: string | null): string {
     .join(' ');
 }
 
+function getInitialPhotos(
+  photos: { storagePath: string; url: string }[],
+): SelectedImage[] {
+  return photos.map((photo) => ({
+    id: photo.storagePath,
+    uri: photo.url,
+    fileName: photo.storagePath.split('/').pop() ?? null,
+    storagePath: photo.storagePath,
+    uploadStatus: 'uploaded',
+    uploadError: null,
+  }));
+}
+
+function getUploadedPhotos(photos: SelectedImage[]) {
+  return photos
+    .filter(
+      (photo) =>
+        photo.uploadStatus === 'uploaded' && Boolean(photo.storagePath),
+    )
+    .slice(0, MAX_IMAGES_PER_UPLOAD)
+    .map((photo) => ({ storagePath: photo.storagePath! }));
+}
+
+function getPhotoKey(paths: { storagePath?: string | null }[]) {
+  return paths
+    .map((photo) => photo.storagePath?.trim())
+    .filter((path): path is string => Boolean(path))
+    .join('|');
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error
+    ? error.message
+    : 'Failed to save moment photos. Please try again.';
+}
+
+function getMomentPhotoValues(moment: {
+  title: string;
+  occurredOn: string;
+  category: string | null;
+  description: string | null;
+}) {
+  return {
+    title: moment.title,
+    occurredAt: parseOccurredAt(moment.occurredOn),
+    momentType: moment.category ?? '',
+    description: moment.description ?? '',
+  };
+}
+
 export default function MomentDetailScreen() {
-  const { width } = useWindowDimensions();
   const { activeGroup, isLoading: isLoadingGroups } = useActiveGroup();
   const params = useLocalSearchParams<{ id?: string | string[] }>();
   const rawId = params.id;
   const momentId = Array.isArray(rawId) ? rawId[0] : rawId;
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [photos, setPhotos] = useState<SelectedImage[]>([]);
+  const [hasLocalPhotoChanges, setHasLocalPhotoChanges] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const lastSubmittedPhotoKeyRef = useRef<string | null>(null);
+  const failedSavePhotoKeyRef = useRef<string | null>(null);
+  const deleteMomentMutation = useDeleteMomentMutation();
+  const updateMomentMutation = useUpdateMomentMutation();
+  const { startUpload } = useImageUpload({
+    bucket: 'moments',
+    setImages: setPhotos,
+  });
   const momentQuery = useMomentDetailQuery(momentId, activeGroup?.id);
   const moment = momentQuery.data;
-  const displayDate = moment ? formatOccurredOn(moment.occurredOn) : '';
+  const momentPhotoKey = getPhotoKey(moment?.photos ?? []);
+  const uploadedPhotoKey = getPhotoKey(getUploadedPhotos(photos));
+  const displayDate = moment?.occurredOn
+    ? formatOccurredOn(moment.occurredOn)
+    : '';
   const displayType = formatMomentType(moment?.category ?? null);
-  const bannerImages = moment?.photos?.length
-    ? moment.photos
-    : [FALLBACK_COVER_IMAGE];
-  const [activeBannerIndex, setActiveBannerIndex] = useState(0);
-  const photoThumbs = moment?.photos?.slice(0, 3) ?? [];
+  const heroImageUrl = photos[0]?.uri ?? moment?.photos[0]?.url ?? null;
+  const heroImageSource = heroImageUrl
+    ? { uri: heroImageUrl }
+    : FALLBACK_COVER_IMAGE;
   const loadError =
     momentQuery.error instanceof Error
       ? momentQuery.error.message
       : momentQuery.error
         ? 'Could not load moment.'
         : null;
+  const hasDescription = Boolean(moment?.description?.trim());
+  const isDeleting = deleteMomentMutation.isPending;
+  const isSavingPhotos = updateMomentMutation.isPending;
+  const isMutatingMoment = isDeleting || isSavingPhotos;
+  const failedUploads = photos.filter(
+    (photo) => photo.uploadStatus === 'failed',
+  );
+  const hasFailedUploads = failedUploads.length > 0;
+  const hasTransientPhotos = photos.some(
+    (photo) => photo.uploadStatus !== 'uploaded',
+  );
+  const hasPendingUploads = photos.some(
+    (photo) =>
+      photo.uploadStatus === 'local' || photo.uploadStatus === 'uploading',
+  );
+  const retryUploadsDisabled =
+    isDeleting || isSavingPhotos || hasPendingUploads;
+  const retrySaveDisabled = isMutatingMoment || hasPendingUploads;
+  const deleteActionLabel = isDeleting
+    ? 'Deleting...'
+    : isSavingPhotos
+      ? 'Saving photos...'
+      : 'Delete moment';
 
-  function handleBannerScroll(event: NativeSyntheticEvent<NativeScrollEvent>) {
-    if (width <= 0) {
+  useEffect(() => {
+    if (!moment) {
       return;
     }
 
-    const nextIndex = Math.round(event.nativeEvent.contentOffset.x / width);
-    setActiveBannerIndex(nextIndex);
+    const nextPhotos = getInitialPhotos(moment.photos);
+
+    if (hasLocalPhotoChanges) {
+      if (!hasTransientPhotos && uploadedPhotoKey === momentPhotoKey) {
+        setHasLocalPhotoChanges(false);
+        setSaveError(null);
+        failedSavePhotoKeyRef.current = null;
+        lastSubmittedPhotoKeyRef.current = momentPhotoKey;
+      }
+
+      return;
+    }
+
+    setPhotos((current) => {
+      const currentUploadedPhotoKey = getPhotoKey(getUploadedPhotos(current));
+      const hasCurrentTransientPhotos = current.some(
+        (photo) => photo.uploadStatus !== 'uploaded',
+      );
+
+      if (
+        hasCurrentTransientPhotos ||
+        (currentUploadedPhotoKey === momentPhotoKey &&
+          current.length === nextPhotos.length)
+      ) {
+        return current;
+      }
+
+      return nextPhotos;
+    });
+
+    lastSubmittedPhotoKeyRef.current = momentPhotoKey;
+  }, [
+    hasLocalPhotoChanges,
+    hasTransientPhotos,
+    moment,
+    momentPhotoKey,
+    uploadedPhotoKey,
+  ]);
+
+  const savePhotos = useCallback(
+    async (nextPhotos: SelectedImage[]) => {
+      if (!momentId || !activeGroup?.id || !moment) {
+        return;
+      }
+
+      const uploadedPhotos = getUploadedPhotos(nextPhotos);
+      const nextPhotoKey = getPhotoKey(uploadedPhotos);
+
+      if (nextPhotoKey === momentPhotoKey) {
+        return;
+      }
+
+      lastSubmittedPhotoKeyRef.current = nextPhotoKey;
+      failedSavePhotoKeyRef.current = null;
+      setSaveError(null);
+
+      try {
+        await updateMomentMutation.mutateAsync({
+          momentId,
+          groupId: activeGroup.id,
+          ...getMomentPhotoValues(moment),
+          photos: uploadedPhotos,
+        });
+      } catch (error) {
+        failedSavePhotoKeyRef.current = nextPhotoKey;
+        lastSubmittedPhotoKeyRef.current = null;
+        setSaveError(getErrorMessage(error));
+      }
+    },
+    [activeGroup?.id, moment, momentId, momentPhotoKey, updateMomentMutation],
+  );
+
+  useEffect(() => {
+    if (!hasLocalPhotoChanges || !moment) {
+      return;
+    }
+
+    if (hasPendingUploads || isSavingPhotos) {
+      return;
+    }
+
+    if (uploadedPhotoKey === momentPhotoKey) {
+      return;
+    }
+
+    if (
+      failedSavePhotoKeyRef.current === uploadedPhotoKey ||
+      lastSubmittedPhotoKeyRef.current === uploadedPhotoKey
+    ) {
+      return;
+    }
+
+    void savePhotos(photos);
+  }, [
+    hasLocalPhotoChanges,
+    hasPendingUploads,
+    isSavingPhotos,
+    moment,
+    momentPhotoKey,
+    photos,
+    savePhotos,
+    uploadedPhotoKey,
+  ]);
+
+  function handlePhotoChange(nextPhotos: SelectedImage[]) {
+    setSaveError(null);
+    setHasLocalPhotoChanges(true);
+    failedSavePhotoKeyRef.current = null;
+    setPhotos(nextPhotos);
   }
+
+  function handleRetryFailedUploads() {
+    setSaveError(null);
+    void startUpload(failedUploads);
+  }
+
+  function handleRetrySave() {
+    failedSavePhotoKeyRef.current = null;
+    void savePhotos(photos);
+  }
+
+  const removeMoment = async () => {
+    if (!momentId || !activeGroup?.id) {
+      return;
+    }
+
+    try {
+      await deleteMomentMutation.mutateAsync({
+        momentId,
+        groupId: activeGroup.id,
+      });
+      router.back();
+    } catch (error) {
+      Alert.alert(
+        'Could not delete moment',
+        error instanceof Error ? error.message : 'Please try again.',
+      );
+    }
+  };
+
+  const handleEdit = () => {
+    setIsMenuOpen(false);
+
+    if (!momentId || isSavingPhotos) {
+      return;
+    }
+
+    router.push(`/moments/new?momentId=${encodeURIComponent(momentId)}`);
+  };
+
+  const handleDelete = () => {
+    setIsMenuOpen(false);
+
+    if (!momentId || !activeGroup?.id || isMutatingMoment) {
+      return;
+    }
+
+    Alert.alert(
+      'Delete moment?',
+      'This moment and its photos will be removed permanently.',
+      [
+        {
+          text: 'Cancel',
+          style: 'cancel',
+        },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => {
+            void removeMoment();
+          },
+        },
+      ],
+    );
+  };
 
   if (isLoadingGroups || momentQuery.isPending) {
     return (
@@ -104,71 +382,27 @@ export default function MomentDetailScreen() {
       </View>
     );
   }
-  const horizontalPadding = 16 * 2; // same as your container paddingHorizontal
-  const availableWidth = width - horizontalPadding;
-  const gap = (availableWidth - ITEM_WIDTH * COLUMNS) / COLUMNS;
 
   return (
     <View style={styles.screen}>
-      <ScrollView
-        bounces={false}
-        contentContainerStyle={styles.content}
-        showsVerticalScrollIndicator={false}
-      >
-        <View style={styles.bannerWrap}>
-          <ScrollView
-            horizontal
-            onMomentumScrollEnd={handleBannerScroll}
-            pagingEnabled
-            showsHorizontalScrollIndicator={false}
-            style={styles.bannerScroll}
-          >
-            {bannerImages.map((bannerImage, index) => (
-              <Image
-                contentFit="cover"
-                key={
-                  typeof bannerImage === 'string'
-                    ? bannerImage
-                    : `fallback-${index}`
-                }
-                source={
-                  typeof bannerImage === 'string'
-                    ? { uri: bannerImage }
-                    : bannerImage
-                }
-                style={[styles.bannerImage, { width }]}
-              />
-            ))}
-          </ScrollView>
-          <View style={styles.bannerOverlay} />
+      <ScrollView bounces={false} showsVerticalScrollIndicator={false}>
+        <View style={styles.heroWrap}>
+          <Image
+            contentFit="cover"
+            source={heroImageSource}
+            style={styles.heroImage}
+          />
+          <View style={styles.heroOverlay} />
 
           <View style={styles.typePill}>
             <Text style={styles.typePillText}>{displayType}</Text>
           </View>
-
-          {bannerImages.length > 1 ? (
-            <View style={styles.bannerDots}>
-              {bannerImages.map((bannerImage, index) => (
-                <View
-                  key={
-                    typeof bannerImage === 'string'
-                      ? `dot-${bannerImage}`
-                      : 'dot-fallback-cover'
-                  }
-                  style={[
-                    styles.bannerDot,
-                    index === activeBannerIndex ? styles.bannerDotActive : null,
-                  ]}
-                />
-              ))}
-            </View>
-          ) : null}
         </View>
 
         <View style={styles.bodyCard}>
           <Text style={styles.title}>{moment.title}</Text>
 
-          <View style={styles.dateRow}>
+          <View style={styles.metaRow}>
             <CalendarDays color={sectionColors.moments} size={14} />
             <Text style={styles.dateText}>{displayDate}</Text>
           </View>
@@ -177,56 +411,75 @@ export default function MomentDetailScreen() {
 
           <View style={styles.section}>
             <Text style={styles.sectionLabel}>Memory</Text>
-            <Text style={styles.sectionBody}>{moment.description ?? ''}</Text>
+            <Text style={styles.sectionBody}>
+              {hasDescription ? moment.description : 'No memory added'}
+            </Text>
           </View>
 
           <Divider color={sectionColors.moments} />
 
           <View style={styles.section}>
-            <Text style={styles.sectionLabel}>Photos</Text>
-            <View style={[styles.photosRow, { gap: gap }]}>
-              {Array.from({ length: 6 }).map((_, index) => {
-                const photo = photoThumbs[index];
+            <AddImageField
+              color={sectionColors.moments}
+              disabled={isMutatingMoment}
+              maxImages={MAX_IMAGES_PER_UPLOAD}
+              onChange={handlePhotoChange}
+              onRequestUpload={startUpload}
+              value={photos}
+            />
 
-                if (!photo) {
-                  return (
-                    <View
-                      key={`placeholder-${index}`}
-                      style={styles.photoPlaceholder}
-                    >
-                      <Text style={styles.photoPlaceholderText}>+</Text>
-                    </View>
-                  );
-                }
+            {hasFailedUploads ? (
+              <Pressable
+                accessibilityHint="Retries failed photo uploads"
+                accessibilityLabel="Retry failed uploads"
+                accessibilityRole="button"
+                disabled={retryUploadsDisabled}
+                onPress={handleRetryFailedUploads}
+                style={({ pressed }) => [
+                  styles.retryButton,
+                  pressed ? styles.retryButtonPressed : null,
+                  retryUploadsDisabled ? styles.retryButtonDisabled : null,
+                ]}
+              >
+                <Text style={styles.retryButtonText}>Retry failed uploads</Text>
+              </Pressable>
+            ) : null}
 
-                return (
-                  <View
-                    key={photo}
-                    style={[
-                      {
-                        display: 'flex',
-                        flex: 3,
-                        gap: gap,
-                        marginHorizontal: 'auto',
-                        flexDirection: 'row',
-                        flexWrap: 'wrap',
-                        alignItems: 'center',
-                        width: '100%',
-                      },
-                    ]}
-                  >
-                    <Image contentFit="cover" source={{ uri: photo }} />
-                  </View>
-                );
-              })}
-            </View>
+            {saveError ? (
+              <>
+                <Text style={styles.fieldErrorText}>{saveError}</Text>
+                <Pressable
+                  accessibilityHint="Retries saving the current moment photos"
+                  accessibilityLabel="Retry saving photos"
+                  accessibilityRole="button"
+                  disabled={retrySaveDisabled}
+                  onPress={handleRetrySave}
+                  style={({ pressed }) => [
+                    styles.retryButton,
+                    pressed ? styles.retryButtonPressed : null,
+                    retrySaveDisabled ? styles.retryButtonDisabled : null,
+                  ]}
+                >
+                  <Text style={styles.retryButtonText}>
+                    Retry saving photos
+                  </Text>
+                </Pressable>
+              </>
+            ) : null}
+
+            {isSavingPhotos ? (
+              <View style={styles.submittingRow}>
+                <ActivityIndicator color={sectionColors.moments} />
+                <Text style={styles.submittingText}>Saving photos...</Text>
+              </View>
+            ) : null}
           </View>
         </View>
       </ScrollView>
 
       <View pointerEvents="box-none" style={styles.topButtons}>
         <Pressable
-          accessibilityHint="Returns to moments list"
+          accessibilityHint="Returns to the moments list"
           accessibilityLabel="Go back"
           accessibilityRole="button"
           onPress={() => router.back()}
@@ -234,7 +487,65 @@ export default function MomentDetailScreen() {
         >
           <ChevronLeft color={baseColors.text} size={22} />
         </Pressable>
+
+        <Pressable
+          accessibilityHint="Opens moment actions"
+          accessibilityLabel="More options"
+          accessibilityRole="button"
+          disabled={isMutatingMoment}
+          onPress={() => setIsMenuOpen(true)}
+          style={[
+            styles.menuButton,
+            isMutatingMoment ? styles.menuButtonDisabled : null,
+          ]}
+        >
+          <Ellipsis color={baseColors.text} size={22} />
+        </Pressable>
       </View>
+
+      <Modal
+        animationType="fade"
+        onRequestClose={() => setIsMenuOpen(false)}
+        transparent
+        visible={isMenuOpen}
+      >
+        <View style={styles.menuOverlay}>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => setIsMenuOpen(false)}
+            style={styles.menuBackdrop}
+          />
+          <View style={styles.menuPanel}>
+            <Pressable
+              accessibilityRole="button"
+              onPress={handleEdit}
+              style={({ pressed }) => [
+                styles.menuAction,
+                pressed ? styles.menuActionPressed : null,
+              ]}
+            >
+              <Text style={styles.menuActionText}>Edit moment</Text>
+            </Pressable>
+
+            <View style={styles.menuDivider} />
+
+            <Pressable
+              accessibilityRole="button"
+              disabled={isMutatingMoment}
+              onPress={handleDelete}
+              style={({ pressed }) => [
+                styles.menuAction,
+                pressed ? styles.menuActionPressed : null,
+                isMutatingMoment ? styles.menuActionDisabled : null,
+              ]}
+            >
+              <Text style={styles.menuActionDangerText}>
+                {deleteActionLabel}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -251,43 +562,51 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingHorizontal: space.xl,
   },
-  content: {
-    paddingBottom: space.xxl,
-  },
-  bannerWrap: {
+  heroWrap: {
     height: 320,
     position: 'relative',
   },
-  bannerScroll: {
-    height: '100%',
+  heroImage: {
+    height: 320,
     width: '100%',
   },
-  bannerImage: {
-    height: '100%',
-  },
-  bannerOverlay: {
+  heroOverlay: {
+    backgroundColor: 'rgba(0, 0, 0, 0.22)',
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.25)',
   },
   topButtons: {
     left: 0,
     position: 'absolute',
     right: 0,
-    top: 40,
+    top: 60,
     zIndex: 1,
   },
   backButton: {
     alignItems: 'center',
-    backgroundColor: 'rgba(0,0,0,0.45)',
-    borderColor: 'rgba(255,255,255,0.15)',
+    backgroundColor: 'rgba(0, 0, 0, 0.45)',
+    borderColor: 'rgba(255, 255, 255, 0.15)',
     borderRadius: radius.full,
     borderWidth: 1,
     height: 40,
     justifyContent: 'center',
-    left: space.lg - 6,
+    left: space.lg,
     position: 'absolute',
-    top: space.lg,
     width: 40,
+  },
+  menuButton: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.45)',
+    borderColor: 'rgba(255, 255, 255, 0.15)',
+    borderRadius: radius.full,
+    borderWidth: 1,
+    height: 40,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: space.lg,
+    width: 40,
+  },
+  menuButtonDisabled: {
+    opacity: 0.45,
   },
   typePill: {
     alignItems: 'center',
@@ -306,33 +625,15 @@ const styles = StyleSheet.create({
     fontSize: textTheme.size.md,
     lineHeight: textTheme.lineHeight.md,
   },
-  bannerDots: {
-    alignItems: 'center',
-    bottom: space.sm,
-    flexDirection: 'row',
-    gap: space.xs,
-    position: 'absolute',
-    right: space.lg,
-  },
-  bannerDot: {
-    backgroundColor: 'rgba(245, 240, 236, 0.45)',
-    borderRadius: radius.full,
-    height: 6,
-    width: 6,
-  },
-  bannerDotActive: {
-    backgroundColor: sectionColors.moments,
-    width: 16,
-  },
   bodyCard: {
     backgroundColor: baseColors.bg,
     borderTopLeftRadius: radius.xl,
     borderTopRightRadius: radius.xl,
     gap: space.lg + space.xs,
     marginTop: -space.lg,
+    paddingBottom: space.xl,
     paddingHorizontal: space.lg,
     paddingTop: space.xl,
-    paddingBottom: space.xl,
   },
   title: {
     color: baseColors.text,
@@ -340,10 +641,10 @@ const styles = StyleSheet.create({
     fontSize: textTheme.size.xxl,
     lineHeight: textTheme.lineHeight.xl,
   },
-  dateRow: {
+  metaRow: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: space.xs + 2,
+    gap: space.sm,
   },
   dateText: {
     color: sectionColors.moments,
@@ -368,39 +669,79 @@ const styles = StyleSheet.create({
     fontSize: textTheme.size.sm,
     lineHeight: textTheme.lineHeight.sm,
   },
-  photosRow: {
-    flexDirection: 'row',
-    flex: 3,
-    flexWrap: 'wrap',
-    justifyContent: 'center',
+  retryButton: {
+    alignSelf: 'flex-start',
+    borderColor: sectionColors.moments,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    paddingHorizontal: space.md,
+    paddingVertical: space.xs,
   },
-  photoThumbWrap: {
-    borderRadius: 14,
-    height: 111,
-    overflow: 'hidden',
-    width: 111,
+  retryButtonPressed: {
+    opacity: 0.82,
   },
-  photoThumb: {
-    width: '100%',
-    height: '100%',
+  retryButtonDisabled: {
+    opacity: 0.45,
   },
-
-  photoPlaceholder: {
+  retryButtonText: {
+    color: sectionColors.moments,
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.xs,
+    lineHeight: textTheme.lineHeight.xs,
+  },
+  submittingRow: {
     alignItems: 'center',
-    backgroundColor: baseColors.card,
-    borderColor: 'rgba(107,101,96,0.27)',
-    borderRadius: 14,
-    borderStyle: 'dashed',
-    borderWidth: 2,
-    height: 111,
-    justifyContent: 'center',
-    width: 111,
+    flexDirection: 'row',
+    gap: space.sm,
   },
-  photoPlaceholderText: {
-    color: baseColors.textMuted,
-    fontFamily: textTheme.family.regular,
+  submittingText: {
+    color: baseColors.textSoft,
+    fontFamily: textTheme.family.medium,
     fontSize: textTheme.size.sm,
-    lineHeight: 33,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  menuOverlay: {
+    flex: 1,
+  },
+  menuBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  menuPanel: {
+    backgroundColor: baseColors.bg,
+    borderColor: 'rgba(107, 101, 96, 0.16)',
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    minWidth: 168,
+    overflow: 'hidden',
+    position: 'absolute',
+    right: space.lg,
+    top: space.lg + 84,
+  },
+  menuAction: {
+    paddingHorizontal: space.lg,
+    paddingVertical: space.md,
+  },
+  menuActionPressed: {
+    opacity: 0.82,
+  },
+  menuActionDisabled: {
+    opacity: 0.45,
+  },
+  menuActionText: {
+    color: baseColors.text,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  menuActionDangerText: {
+    color: baseColors.textError,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  menuDivider: {
+    backgroundColor: 'rgba(107, 101, 96, 0.12)',
+    height: 1,
   },
   errorText: {
     color: baseColors.textError,
@@ -409,10 +750,14 @@ const styles = StyleSheet.create({
     lineHeight: textTheme.lineHeight.sm,
     textAlign: 'center',
   },
+  fieldErrorText: {
+    color: baseColors.textError,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.xs,
+    lineHeight: textTheme.lineHeight.xs,
+  },
   backTextButton: {
-    marginTop: space.md,
-    paddingHorizontal: space.md,
-    paddingVertical: space.xs,
+    marginTop: space.lg,
   },
   backText: {
     color: sectionColors.moments,

--- a/app/moments/new.tsx
+++ b/app/moments/new.tsx
@@ -1,315 +1,202 @@
-import { DatePicker } from '@/components/DatePicker';
+import MomentForm from '@/components/MomentForm';
 import ModalTopBar from '@/components/ModalTopBar';
-import {
-  AddImageField,
-  type SelectedImage,
-} from '@/components/ui/AddImageField';
+import { type SelectedImage } from '@/components/ui/AddImageField';
 import Divider from '@/components/ui/Divider';
-import { Dropdown } from '@/components/ui/Dropdown';
-import { Input } from '@/components/ui/Input';
 import { Text } from '@/components/ui/Text';
 import { useActiveGroup } from '@/hooks/useActiveGroup';
-import { useImageUpload } from '@/hooks/useImageUpload';
-import { useCreateMomentMutation } from '@/hooks/useMoments';
-import { MAX_IMAGES_PER_UPLOAD } from '@/lib/images';
-import {
-  type CreateMomentValues,
-  createMomentSchema,
-} from '@/lib/validation/moment';
+import { useMomentDetailQuery } from '@/hooks/useMoments';
+import { type CreateMomentValues } from '@/lib/validation/moment';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
-import { useForm } from '@tanstack/react-form';
-import { router } from 'expo-router';
-import { useMemo, useState } from 'react';
+import {
+  router,
+  useGlobalSearchParams,
+  useLocalSearchParams,
+} from 'expo-router';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
-  Pressable,
-  ScrollView,
   StyleSheet,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-const SAVE_TIMEOUT_MS = 10000;
+const EMPTY_VALUES: CreateMomentValues = {
+  momentType: '',
+  title: '',
+  description: '',
+  occurredAt: new Date(),
+};
 
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      reject(new Error('Failed to save moment. Please try again.'));
-    }, timeoutMs);
+function getParamValue(value?: string | string[]): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
 
-    promise.then(
-      (value) => {
-        clearTimeout(timeoutId);
-        resolve(value);
-      },
-      (error) => {
-        clearTimeout(timeoutId);
-        reject(error);
-      },
-    );
-  });
+function parseOccurredAt(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number);
+
+  if ([year, month, day].every((part) => Number.isFinite(part))) {
+    return new Date(year, month - 1, day);
+  }
+
+  const parsed = new Date(value);
+
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+function getInitialValues(moment: {
+  title: string;
+  description: string | null;
+  category: string | null;
+  occurredOn: string;
+}): CreateMomentValues {
+  return {
+    momentType: moment.category ?? '',
+    title: moment.title,
+    description: moment.description ?? '',
+    occurredAt: parseOccurredAt(moment.occurredOn),
+  };
+}
+
+function getInitialPhotos(
+  photos: { storagePath: string; url: string }[],
+): SelectedImage[] {
+  return photos.map((photo) => ({
+    id: photo.storagePath,
+    uri: photo.url,
+    fileName: photo.storagePath.split('/').pop() ?? null,
+    storagePath: photo.storagePath,
+    uploadStatus: 'uploaded',
+    uploadError: null,
+  }));
+}
+
+function getLoadError(options: {
+  activeGroupId: string | null | undefined;
+  error: unknown;
+  hasMoment: boolean;
+  isEdit: boolean;
+  isLoadingGroups: boolean;
+  isMomentPending: boolean;
+}): string | null {
+  const {
+    activeGroupId,
+    error,
+    hasMoment,
+    isEdit,
+    isLoadingGroups,
+    isMomentPending,
+  } = options;
+
+  if (!isEdit) {
+    return null;
+  }
+
+  if (!isLoadingGroups && !activeGroupId) {
+    return 'Choose a space before editing this moment.';
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (error) {
+    return 'Could not load moment.';
+  }
+
+  if (!isLoadingGroups && !isMomentPending && !hasMoment) {
+    return 'Moment not found.';
+  }
+
+  return null;
 }
 
 export default function NewMomentScreen() {
-  const { activeGroup } = useActiveGroup();
-  const [photos, setPhotos] = useState<SelectedImage[]>([]);
-  const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const createMomentMutation = useCreateMomentMutation();
-  const { startUpload } = useImageUpload({
-    bucket: 'moments',
-    setImages: setPhotos,
-  });
-  const isUploading = photos.some(
-    (photo) => photo.uploadStatus === 'uploading',
+  const { activeGroup, isLoading: isLoadingGroups } = useActiveGroup();
+  const localParams = useLocalSearchParams<{
+    momentId?: string | string[];
+    id?: string | string[];
+  }>();
+  const globalParams = useGlobalSearchParams<{
+    momentId?: string | string[];
+    id?: string | string[];
+  }>();
+  const momentId = getParamValue(
+    localParams.momentId ??
+      globalParams.momentId ??
+      localParams.id ??
+      globalParams.id,
   );
-  const failedUploads = photos.filter(
-    (photo) => photo.uploadStatus === 'failed',
-  );
-  const hasFailedUploads = failedUploads.length > 0;
-  const firstFailedUploadError =
-    failedUploads.find((photo) => Boolean(photo.uploadError))?.uploadError ??
-    null;
-
-  const momentTypeOptions = [
-    { label: 'Food', value: 'food' },
-    { label: 'Outfit', value: 'outfit' },
-    { label: 'Tiny Joy', value: 'tiny-joy' },
-    { label: 'Cozy Scene', value: 'cozy-scene' },
-    { label: 'Nature', value: 'nature' },
-    { label: 'Connection', value: 'connection' },
-    { label: 'Personal Win', value: 'personal-win' },
-  ];
-
-  const form = useForm({
-    defaultValues: {
-      momentType: '',
-      title: '',
-      description: '',
-      occurredAt: new Date(),
-    } satisfies CreateMomentValues,
-    onSubmit: async ({ value }) => {
-      const parsed = createMomentSchema.safeParse(value);
-      if (!parsed.success) {
-        throw new Error(parsed.error.issues[0]?.message ?? 'Invalid input.');
-      }
-
-      if (!activeGroup?.id) {
-        throw new Error('Choose a space before saving this moment.');
-      }
-
-      const uploadedPhotos = photos
-        .filter(
-          (photo) =>
-            photo.uploadStatus === 'uploaded' && Boolean(photo.storagePath),
-        )
-        .slice(0, MAX_IMAGES_PER_UPLOAD)
-        .map((photo) => ({ storagePath: photo.storagePath! }));
-
-      try {
-        await createMomentMutation.mutateAsync({
-          ...parsed.data,
-          groupId: activeGroup.id,
-          photos: uploadedPhotos,
-        });
-      } catch (error) {
-        if (error instanceof Error) {
-          throw error;
-        }
-        throw new Error('Failed to save moment. Please try again.');
-      }
-
-      router.back();
-    },
+  const isEdit = Boolean(momentId);
+  const momentQuery = useMomentDetailQuery(momentId, activeGroup?.id);
+  const moment = momentQuery.data;
+  const isLoadingMoment = isEdit && (isLoadingGroups || momentQuery.isPending);
+  const loadError = getLoadError({
+    activeGroupId: activeGroup?.id,
+    error: momentQuery.error,
+    hasMoment: Boolean(moment),
+    isEdit,
+    isLoadingGroups,
+    isMomentPending: momentQuery.isPending,
   });
 
-  const validation = useMemo(
-    () => createMomentSchema.safeParse(form.state.values),
-    [form.state.values],
-  );
-  const fieldErrors = validation.success
-    ? {}
-    : validation.error.flatten().fieldErrors;
-  const submitError = saveError ?? form.state.errorMap.onSubmit;
+  if (isLoadingMoment) {
+    return (
+      <SafeAreaView style={styles.screen} edges={['top']}>
+        <KeyboardAvoidingView
+          style={styles.screen}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        >
+          <ModalTopBar
+            color={sectionColors.moments}
+            onClose={() => router.back()}
+            title="Edit Moment"
+          />
+          <Divider color={sectionColors.moments} />
+          <View style={styles.loadingState}>
+            <ActivityIndicator color={sectionColors.moments} />
+            <Text style={styles.submittingText}>Loading moment...</Text>
+          </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    );
+  }
 
-  const handleSave = async () => {
-    if (isSaving) {
-      return;
-    }
+  if (loadError) {
+    return (
+      <SafeAreaView style={styles.screen} edges={['top']}>
+        <KeyboardAvoidingView
+          style={styles.screen}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        >
+          <ModalTopBar
+            color={sectionColors.moments}
+            onClose={() => router.back()}
+            title="Edit Moment"
+          />
+          <Divider color={sectionColors.moments} />
+          <View style={styles.loadingState}>
+            <Text style={styles.errorText}>{loadError}</Text>
+          </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    );
+  }
 
-    setHasTriedSubmit(true);
-    setSaveError(null);
-    const parsed = createMomentSchema.safeParse(form.state.values);
-    if (!parsed.success) {
-      return;
-    }
-
-    if (!activeGroup?.id) {
-      setSaveError('Choose a space before saving this moment.');
-      return;
-    }
-
-    if (isUploading) {
-      setSaveError('Please wait for photos to finish uploading.');
-      return;
-    }
-
-    if (hasFailedUploads) {
-      setSaveError(
-        firstFailedUploadError
-          ? `Some photos failed to upload: ${firstFailedUploadError}`
-          : 'Some photos failed to upload. Remove or retry them before saving.',
-      );
-      return;
-    }
-
-    setIsSaving(true);
-
-    try {
-      await withTimeout(form.handleSubmit(), SAVE_TIMEOUT_MS);
-    } catch (error) {
-      if (error instanceof Error) {
-        setSaveError(error.message);
-      } else {
-        setSaveError('Failed to save moment. Please try again.');
-      }
-      setIsSaving(false);
-    }
-  };
+  const initialValues = moment ? getInitialValues(moment) : EMPTY_VALUES;
+  const initialPhotos = moment ? getInitialPhotos(moment.photos) : [];
 
   return (
-    <SafeAreaView style={styles.screen} edges={['top']}>
-      <KeyboardAvoidingView
-        style={styles.screen}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      >
-        <ModalTopBar
-          color={sectionColors.moments}
-          onClose={() => router.back()}
-          onSave={handleSave}
-          title="New Moment"
-        />
-        <Divider color={sectionColors.moments} />
-
-        <ScrollView
-          automaticallyAdjustKeyboardInsets
-          contentContainerStyle={styles.content}
-          contentInsetAdjustmentBehavior="automatic"
-          keyboardDismissMode="interactive"
-          keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={false}
-        >
-          <View style={styles.form}>
-            <form.Field name="momentType">
-              {(field) => (
-                <Dropdown
-                  color={sectionColors.moments}
-                  onChange={field.handleChange}
-                  options={momentTypeOptions}
-                  placeholder="Moment type"
-                  value={field.state.value || undefined}
-                />
-              )}
-            </form.Field>
-            {hasTriedSubmit && fieldErrors.momentType?.[0] ? (
-              <Text style={styles.errorText}>{fieldErrors.momentType[0]}</Text>
-            ) : null}
-
-            <form.Field name="title">
-              {(field) => (
-                <Input
-                  label="Title"
-                  onBlur={field.handleBlur}
-                  onChangeText={field.handleChange}
-                  placeholder="Give this moment a memorable title..."
-                  value={field.state.value}
-                />
-              )}
-            </form.Field>
-            {hasTriedSubmit && fieldErrors.title?.[0] ? (
-              <Text style={styles.errorText}>{fieldErrors.title[0]}</Text>
-            ) : null}
-
-            <form.Field name="occurredAt">
-              {(field) => (
-                <DatePicker
-                  color={sectionColors.moments}
-                  label="Date"
-                  onChange={field.handleChange}
-                  required
-                  value={field.state.value}
-                />
-              )}
-            </form.Field>
-            {hasTriedSubmit && fieldErrors.occurredAt?.[0] ? (
-              <Text style={styles.errorText}>{fieldErrors.occurredAt[0]}</Text>
-            ) : null}
-
-            <form.Field name="description">
-              {(field) => (
-                <Input
-                  label="Description"
-                  minRows={4}
-                  onBlur={field.handleBlur}
-                  onChangeText={field.handleChange}
-                  placeholder="Describe this special moment..."
-                  required
-                  value={field.state.value}
-                  variant="textarea"
-                />
-              )}
-            </form.Field>
-            {hasTriedSubmit && fieldErrors.description?.[0] ? (
-              <Text style={styles.errorText}>{fieldErrors.description[0]}</Text>
-            ) : null}
-
-            <AddImageField
-              color={sectionColors.moments}
-              maxImages={MAX_IMAGES_PER_UPLOAD}
-              onChange={setPhotos}
-              onRequestUpload={startUpload}
-              value={photos}
-            />
-
-            {hasFailedUploads ? (
-              <Pressable
-                accessibilityHint="Retries failed photo uploads"
-                accessibilityLabel="Retry failed uploads"
-                accessibilityRole="button"
-                disabled={isUploading || isSaving}
-                onPress={() => {
-                  setSaveError(null);
-                  void startUpload(failedUploads);
-                }}
-                style={({ pressed }) => [
-                  styles.retryButton,
-                  pressed ? styles.retryButtonPressed : null,
-                  isUploading || isSaving ? styles.retryButtonDisabled : null,
-                ]}
-              >
-                <Text style={styles.retryButtonText}>Retry failed uploads</Text>
-              </Pressable>
-            ) : null}
-
-            {submitError ? (
-              <Text style={styles.errorText}>{submitError}</Text>
-            ) : null}
-
-            {isSaving ? (
-              <View style={styles.submittingRow}>
-                <ActivityIndicator color={sectionColors.moments} />
-                <Text style={styles.submittingText}>Saving moment...</Text>
-              </View>
-            ) : null}
-          </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+    <MomentForm
+      key={`${momentId ?? 'new'}:${activeGroup?.id ?? 'no-group'}`}
+      activeGroupId={activeGroup?.id ?? null}
+      initialPhotos={initialPhotos}
+      initialValues={initialValues}
+      isEdit={isEdit}
+      momentId={momentId}
+    />
   );
 }
 
@@ -318,18 +205,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: baseColors.bg,
   },
-  content: {
-    paddingHorizontal: space.lg,
-    paddingTop: space.lg,
-    paddingBottom: space.xxl,
-    gap: space.xl,
-  },
-  form: {
-    gap: space.xl,
-  },
-  dropdownField: {
-    gap: space.sm,
-  },
   errorText: {
     color: baseColors.textError,
     fontFamily: textTheme.family.medium,
@@ -337,35 +212,17 @@ const styles = StyleSheet.create({
     lineHeight: textTheme.lineHeight.xs,
     marginTop: -space.md,
   },
-  submittingRow: {
+  loadingState: {
     alignItems: 'center',
-    flexDirection: 'row',
+    flex: 1,
     gap: space.sm,
+    justifyContent: 'center',
+    paddingHorizontal: space.lg,
   },
   submittingText: {
     color: baseColors.textSoft,
     fontFamily: textTheme.family.medium,
     fontSize: textTheme.size.sm,
     lineHeight: textTheme.lineHeight.sm,
-  },
-  retryButton: {
-    alignSelf: 'flex-start',
-    borderColor: sectionColors.moments,
-    borderRadius: 999,
-    borderWidth: 1,
-    paddingHorizontal: space.md,
-    paddingVertical: space.xs,
-  },
-  retryButtonText: {
-    color: sectionColors.moments,
-    fontFamily: textTheme.family.semiBold,
-    fontSize: textTheme.size.sm,
-    lineHeight: textTheme.lineHeight.sm,
-  },
-  retryButtonPressed: {
-    opacity: 0.82,
-  },
-  retryButtonDisabled: {
-    opacity: 0.45,
   },
 });

--- a/components/MomentForm.tsx
+++ b/components/MomentForm.tsx
@@ -1,0 +1,404 @@
+import { DatePicker } from '@/components/DatePicker';
+import ModalTopBar from '@/components/ModalTopBar';
+import {
+  AddImageField,
+  type SelectedImage,
+} from '@/components/ui/AddImageField';
+import Divider from '@/components/ui/Divider';
+import { Dropdown } from '@/components/ui/Dropdown';
+import { Input } from '@/components/ui/Input';
+import { Text } from '@/components/ui/Text';
+import {
+  useCreateMomentMutation,
+  useUpdateMomentMutation,
+} from '@/hooks/useMoments';
+import { useImageUpload } from '@/hooks/useImageUpload';
+import { MAX_IMAGES_PER_UPLOAD } from '@/lib/images';
+import {
+  createMomentSchema,
+  type CreateMomentValues,
+} from '@/lib/validation/moment';
+import { baseColors, sectionColors } from '@/theme/colors';
+import { space } from '@/theme/space';
+import { text as textTheme } from '@/theme/type';
+import { useForm } from '@tanstack/react-form';
+import { router } from 'expo-router';
+import { useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+const SAVE_TIMEOUT_MS = 10000;
+const MOMENT_TYPE_OPTIONS = [
+  { label: 'Food', value: 'food' },
+  { label: 'Outfit', value: 'outfit' },
+  { label: 'Tiny Joy', value: 'tiny-joy' },
+  { label: 'Cozy Scene', value: 'cozy-scene' },
+  { label: 'Nature', value: 'nature' },
+  { label: 'Connection', value: 'connection' },
+  { label: 'Personal Win', value: 'personal-win' },
+];
+
+export type MomentFormProps = {
+  activeGroupId: string | null;
+  momentId?: string;
+  initialPhotos: SelectedImage[];
+  initialValues: CreateMomentValues;
+  isEdit: boolean;
+};
+
+function getUploadedPhotos(photos: SelectedImage[]) {
+  return photos
+    .filter(
+      (photo) =>
+        photo.uploadStatus === 'uploaded' && Boolean(photo.storagePath),
+    )
+    .slice(0, MAX_IMAGES_PER_UPLOAD)
+    .map((photo) => ({ storagePath: photo.storagePath! }));
+}
+
+function getFailedUploadMessage(uploadError: string | null) {
+  return uploadError
+    ? `Some photos failed to upload: ${uploadError}`
+    : 'Some photos failed to upload. Remove or retry them before saving.';
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error
+    ? error.message
+    : 'Failed to save moment. Please try again.';
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error('Failed to save moment. Please try again.'));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
+}
+
+export default function MomentForm({
+  activeGroupId,
+  momentId,
+  initialPhotos,
+  initialValues,
+  isEdit,
+}: MomentFormProps) {
+  const [photos, setPhotos] = useState(initialPhotos);
+  const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const createMomentMutation = useCreateMomentMutation();
+  const updateMomentMutation = useUpdateMomentMutation();
+  const { startUpload } = useImageUpload({
+    bucket: 'moments',
+    setImages: setPhotos,
+  });
+  const isUploading = photos.some(
+    (photo) => photo.uploadStatus === 'uploading',
+  );
+  const failedUploads = photos.filter(
+    (photo) => photo.uploadStatus === 'failed',
+  );
+  const hasFailedUploads = failedUploads.length > 0;
+  const firstFailedUploadError =
+    failedUploads.find((photo) => Boolean(photo.uploadError))?.uploadError ??
+    null;
+  const uploadedPhotos = getUploadedPhotos(photos);
+  const retryUploadsDisabled = isUploading || isSaving;
+
+  const saveMoment = async (values: CreateMomentValues, groupId: string) => {
+    if (isEdit && momentId) {
+      await updateMomentMutation.mutateAsync({
+        momentId,
+        ...values,
+        groupId,
+        photos: uploadedPhotos,
+      });
+      return;
+    }
+
+    await createMomentMutation.mutateAsync({
+      ...values,
+      groupId,
+      photos: uploadedPhotos,
+    });
+  };
+
+  const form = useForm({
+    defaultValues: initialValues,
+    onSubmit: async ({ value }) => {
+      const parsed = createMomentSchema.safeParse(value);
+
+      if (!parsed.success) {
+        throw new Error(parsed.error.issues[0]?.message ?? 'Invalid input.');
+      }
+
+      if (!activeGroupId) {
+        throw new Error('Choose a space before saving this moment.');
+      }
+
+      try {
+        await saveMoment(parsed.data, activeGroupId);
+      } catch (error) {
+        if (error instanceof Error) {
+          throw error;
+        }
+
+        throw new Error('Failed to save moment. Please try again.');
+      }
+
+      router.back();
+    },
+  });
+
+  const validation = useMemo(
+    () => createMomentSchema.safeParse(form.state.values),
+    [form.state.values],
+  );
+  const fieldErrors = validation.success
+    ? {}
+    : validation.error.flatten().fieldErrors;
+  const submitError = saveError ?? form.state.errorMap.onSubmit;
+
+  const handleSave = async () => {
+    if (isSaving) {
+      return;
+    }
+
+    setHasTriedSubmit(true);
+    setSaveError(null);
+    if (!validation.success) {
+      return;
+    }
+
+    if (isUploading) {
+      setSaveError('Please wait for photos to finish uploading.');
+      return;
+    }
+
+    if (hasFailedUploads) {
+      setSaveError(getFailedUploadMessage(firstFailedUploadError));
+      return;
+    }
+
+    if (!activeGroupId) {
+      setSaveError('Choose a space before saving this moment.');
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      await withTimeout(form.handleSubmit(), SAVE_TIMEOUT_MS);
+    } catch (error) {
+      setSaveError(getErrorMessage(error));
+      setIsSaving(false);
+    }
+  };
+
+  function handleRetryFailedUploads() {
+    setSaveError(null);
+    void startUpload(failedUploads);
+  }
+
+  return (
+    <SafeAreaView style={styles.screen} edges={['top']}>
+      <KeyboardAvoidingView
+        style={styles.screen}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ModalTopBar
+          color={sectionColors.moments}
+          onClose={() => router.back()}
+          onSave={handleSave}
+          title={isEdit ? 'Edit Moment' : 'New Moment'}
+        />
+        <Divider color={sectionColors.moments} />
+
+        <ScrollView
+          automaticallyAdjustKeyboardInsets
+          contentContainerStyle={styles.content}
+          contentInsetAdjustmentBehavior="automatic"
+          keyboardDismissMode="interactive"
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={styles.form}>
+            <form.Field name="momentType">
+              {(field) => (
+                <Dropdown
+                  color={sectionColors.moments}
+                  onChange={field.handleChange}
+                  options={MOMENT_TYPE_OPTIONS}
+                  placeholder="Moment type"
+                  value={field.state.value || undefined}
+                />
+              )}
+            </form.Field>
+            {hasTriedSubmit && fieldErrors.momentType?.[0] ? (
+              <Text style={styles.errorText}>{fieldErrors.momentType[0]}</Text>
+            ) : null}
+
+            <form.Field name="title">
+              {(field) => (
+                <Input
+                  label="Title"
+                  onBlur={field.handleBlur}
+                  onChangeText={field.handleChange}
+                  placeholder="Give this moment a memorable title..."
+                  required
+                  value={field.state.value}
+                />
+              )}
+            </form.Field>
+            {hasTriedSubmit && fieldErrors.title?.[0] ? (
+              <Text style={styles.errorText}>{fieldErrors.title[0]}</Text>
+            ) : null}
+
+            <form.Field name="occurredAt">
+              {(field) => (
+                <DatePicker
+                  color={sectionColors.moments}
+                  label="Date"
+                  onChange={field.handleChange}
+                  required
+                  value={field.state.value}
+                />
+              )}
+            </form.Field>
+            {hasTriedSubmit && fieldErrors.occurredAt?.[0] ? (
+              <Text style={styles.errorText}>{fieldErrors.occurredAt[0]}</Text>
+            ) : null}
+
+            <form.Field name="description">
+              {(field) => (
+                <Input
+                  label="Description"
+                  minRows={4}
+                  onBlur={field.handleBlur}
+                  onChangeText={field.handleChange}
+                  placeholder="Describe this special moment..."
+                  required
+                  value={field.state.value}
+                  variant="textarea"
+                />
+              )}
+            </form.Field>
+            {hasTriedSubmit && fieldErrors.description?.[0] ? (
+              <Text style={styles.errorText}>{fieldErrors.description[0]}</Text>
+            ) : null}
+
+            <AddImageField
+              color={sectionColors.moments}
+              maxImages={MAX_IMAGES_PER_UPLOAD}
+              onChange={setPhotos}
+              onRequestUpload={startUpload}
+              value={photos}
+            />
+
+            {hasFailedUploads ? (
+              <Pressable
+                accessibilityHint="Retries failed photo uploads"
+                accessibilityLabel="Retry failed uploads"
+                accessibilityRole="button"
+                disabled={retryUploadsDisabled}
+                onPress={handleRetryFailedUploads}
+                style={({ pressed }) => [
+                  styles.retryButton,
+                  pressed ? styles.retryButtonPressed : null,
+                  retryUploadsDisabled ? styles.retryButtonDisabled : null,
+                ]}
+              >
+                <Text style={styles.retryButtonText}>Retry failed uploads</Text>
+              </Pressable>
+            ) : null}
+
+            {submitError ? (
+              <Text style={styles.errorText}>{submitError}</Text>
+            ) : null}
+
+            {isSaving ? (
+              <View style={styles.submittingRow}>
+                <ActivityIndicator color={sectionColors.moments} />
+                <Text style={styles.submittingText}>Saving moment...</Text>
+              </View>
+            ) : null}
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: baseColors.bg,
+  },
+  content: {
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
+    paddingBottom: space.xxl,
+    gap: space.xl,
+  },
+  form: {
+    gap: space.xl,
+  },
+  errorText: {
+    color: baseColors.textError,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.xs,
+    lineHeight: textTheme.lineHeight.xs,
+    marginTop: -space.md,
+  },
+  submittingRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: space.sm,
+  },
+  submittingText: {
+    color: baseColors.textSoft,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  retryButton: {
+    alignSelf: 'flex-start',
+    borderColor: sectionColors.moments,
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: space.md,
+    paddingVertical: space.xs,
+  },
+  retryButtonText: {
+    color: sectionColors.moments,
+    fontFamily: textTheme.family.semiBold,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  retryButtonPressed: {
+    opacity: 0.82,
+  },
+  retryButtonDisabled: {
+    opacity: 0.45,
+  },
+});

--- a/hooks/useMoments.ts
+++ b/hooks/useMoments.ts
@@ -1,7 +1,9 @@
 import {
   createMoment,
+  deleteMoment,
   getMomentById,
   listMomentsForGroup,
+  updateMoment,
 } from '@/services/moments';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -44,6 +46,38 @@ export function useCreateMomentMutation() {
 
   return useMutation({
     mutationFn: createMoment,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: momentKeys.all,
+      });
+    },
+  });
+}
+
+export function useUpdateMomentMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateMoment,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: momentKeys.all,
+      });
+    },
+  });
+}
+
+export function useDeleteMomentMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      momentId,
+      groupId,
+    }: {
+      momentId: string;
+      groupId: string;
+    }) => deleteMoment(momentId, groupId),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: momentKeys.all,

--- a/services/moments.ts
+++ b/services/moments.ts
@@ -1,4 +1,8 @@
-import { getSignedImageUrlMap, MAX_IMAGES_PER_UPLOAD } from '@/lib/images';
+import {
+  getSignedImageUrlMap,
+  IMAGE_BUCKET_ID,
+  MAX_IMAGES_PER_UPLOAD,
+} from '@/lib/images';
 import { supabase } from '@/lib/supabase';
 import {
   getCurrentUserId,
@@ -20,6 +24,10 @@ export type CreateMomentInput = {
   photos: MomentPhotoInput[];
 };
 
+export type UpdateMomentInput = CreateMomentInput & {
+  momentId: string;
+};
+
 export type MomentListItem = {
   id: string;
   title: string;
@@ -29,19 +37,157 @@ export type MomentListItem = {
   coverImage?: string;
 };
 
+export type MomentDetailPhoto = {
+  storagePath: string;
+  url: string;
+};
+
 export type MomentDetail = {
   id: string;
   title: string;
   description: string | null;
   category: string | null;
   occurredOn: string;
-  photos: string[];
+  photos: MomentDetailPhoto[];
 };
 
 type MomentPhotoLink = {
   moment_id?: string | null;
+  photo_id?: string | null;
   photos?: JoinedPhoto;
 };
+
+type InsertedPhotoRow = {
+  id: string;
+  storage_path: string;
+};
+
+type CollectedPhotoRefs = {
+  idsByPath: Map<string, string>;
+  photoIds: string[];
+  storagePaths: string[];
+};
+
+function assertPhotoLimit(photoCount: number) {
+  if (photoCount > MAX_IMAGES_PER_UPLOAD) {
+    throw new Error(
+      `You can attach at most ${MAX_IMAGES_PER_UPLOAD} photos to a moment.`,
+    );
+  }
+}
+
+function getMomentValues(input: CreateMomentInput) {
+  return {
+    category: input.momentType.trim(),
+    title: input.title.trim(),
+    description: input.description.trim(),
+    occurred_on: input.occurredAt.toISOString().slice(0, 10),
+  };
+}
+
+function normalizePhotoPaths(photos: MomentPhotoInput[]): string[] {
+  const seen = new Set<string>();
+  const paths: string[] = [];
+
+  for (const photo of photos) {
+    const path = photo.storagePath?.trim();
+
+    if (!path || seen.has(path)) {
+      continue;
+    }
+
+    seen.add(path);
+    paths.push(path);
+  }
+
+  return paths;
+}
+
+function collectPhotoRefs(links: MomentPhotoLink[]): CollectedPhotoRefs {
+  const idsByPath = new Map<string, string>();
+  const photoIds: string[] = [];
+  const storagePaths: string[] = [];
+
+  for (const link of links) {
+    const storagePath = resolvePhotoStoragePath(link.photos);
+
+    if (link.photo_id) {
+      photoIds.push(link.photo_id);
+    }
+
+    if (!storagePath) {
+      continue;
+    }
+
+    storagePaths.push(storagePath);
+
+    if (link.photo_id) {
+      idsByPath.set(storagePath, link.photo_id);
+    }
+  }
+
+  return {
+    idsByPath,
+    photoIds,
+    storagePaths,
+  };
+}
+
+async function insertPhotos(
+  groupId: string,
+  userId: string,
+  occurredAt: Date,
+  storagePaths: string[],
+): Promise<Map<string, string>> {
+  const photoIds = new Map<string, string>();
+
+  if (storagePaths.length === 0) {
+    return photoIds;
+  }
+
+  const { data, error } = await supabase
+    .from('photos')
+    .insert(
+      storagePaths.map((storagePath) => ({
+        group_id: groupId,
+        uploaded_by: userId,
+        storage_path: storagePath,
+        caption: null,
+        taken_at: occurredAt.toISOString(),
+      })),
+    )
+    .select('id, storage_path');
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  for (const photo of (data ?? []) as InsertedPhotoRow[]) {
+    photoIds.set(photo.storage_path, photo.id);
+  }
+
+  return photoIds;
+}
+
+async function removeStoragePaths(storagePaths: string[]) {
+  if (storagePaths.length === 0) {
+    return;
+  }
+
+  await supabase.storage.from(IMAGE_BUCKET_ID).remove(storagePaths);
+}
+
+async function cleanupPhotos(photoIds: string[], storagePaths: string[]) {
+  try {
+    if (photoIds.length > 0) {
+      await supabase.from('photos').delete().in('id', photoIds);
+    }
+
+    await removeStoragePaths(storagePaths);
+  } catch {
+    // Cleanup is best-effort after the moment mutation succeeds.
+  }
+}
 
 export async function listMomentsForGroup(
   groupId: string,
@@ -111,15 +257,12 @@ export async function listMomentsForGroup(
 }
 
 export async function createMoment(input: CreateMomentInput): Promise<string> {
-  if (input.photos.length > MAX_IMAGES_PER_UPLOAD) {
-    throw new Error(
-      `You can attach at most ${MAX_IMAGES_PER_UPLOAD} photos to a moment.`,
-    );
-  }
+  assertPhotoLimit(input.photos.length);
 
   const userId = await requireCurrentUserId(
     'You must be signed in to create a moment.',
   );
+
   if (!input.groupId) {
     throw new Error('A group must be selected before creating a moment.');
   }
@@ -129,10 +272,7 @@ export async function createMoment(input: CreateMomentInput): Promise<string> {
     .insert({
       group_id: input.groupId,
       created_by: userId,
-      category: input.momentType,
-      title: input.title.trim(),
-      description: input.description.trim(),
-      occurred_on: input.occurredAt.toISOString().slice(0, 10),
+      ...getMomentValues(input),
     })
     .select('id')
     .single();
@@ -145,40 +285,28 @@ export async function createMoment(input: CreateMomentInput): Promise<string> {
     throw new Error('Could not create moment.');
   }
 
-  const persistedPhotoCandidates = input.photos.filter((photo) =>
-    Boolean(photo.storagePath),
-  );
+  const storagePaths = normalizePhotoPaths(input.photos);
 
-  if (persistedPhotoCandidates.length === 0) {
+  if (storagePaths.length === 0) {
     return insertedMoment.id;
   }
 
-  const { data: insertedPhotos, error: photosError } = await supabase
-    .from('photos')
-    .insert(
-      persistedPhotoCandidates.map((photo) => ({
-        group_id: input.groupId,
-        uploaded_by: userId,
-        storage_path: photo.storagePath!,
-        caption: null,
-        taken_at: input.occurredAt.toISOString(),
-      })),
-    )
-    .select('id');
+  const insertedPhotoIds = await insertPhotos(
+    input.groupId,
+    userId,
+    input.occurredAt,
+    storagePaths,
+  );
 
-  if (photosError) {
-    throw new Error(photosError.message);
-  }
-
-  if (!insertedPhotos?.length) {
+  if (insertedPhotoIds.size === 0) {
     return insertedMoment.id;
   }
 
   const { error: linksError } = await supabase.from('moment_photos').insert(
-    insertedPhotos.map((photo, index) => ({
+    storagePaths.map((storagePath, index) => ({
       group_id: input.groupId,
       moment_id: insertedMoment.id,
-      photo_id: photo.id,
+      photo_id: insertedPhotoIds.get(storagePath)!,
       sort_order: index,
     })),
   );
@@ -188,6 +316,163 @@ export async function createMoment(input: CreateMomentInput): Promise<string> {
   }
 
   return insertedMoment.id;
+}
+
+export async function updateMoment(input: UpdateMomentInput): Promise<string> {
+  assertPhotoLimit(input.photos.length);
+
+  const userId = await requireCurrentUserId(
+    'You must be signed in to edit a moment.',
+  );
+
+  if (!input.groupId) {
+    throw new Error('A group must be selected before editing a moment.');
+  }
+
+  if (!input.momentId) {
+    throw new Error('Moment not found.');
+  }
+
+  const { data: updatedMoment, error: momentError } = await supabase
+    .from('moments')
+    .update(getMomentValues(input))
+    .eq('id', input.momentId)
+    .eq('group_id', input.groupId)
+    .select('id')
+    .single();
+
+  if (momentError) {
+    throw new Error(momentError.message);
+  }
+
+  if (!updatedMoment?.id) {
+    throw new Error('Could not update moment.');
+  }
+
+  const { data: currentLinks, error: currentLinksError } = await supabase
+    .from('moment_photos')
+    .select('photo_id, photos(storage_path)')
+    .eq('moment_id', input.momentId)
+    .eq('group_id', input.groupId)
+    .order('sort_order', { ascending: true });
+
+  if (currentLinksError) {
+    throw new Error(currentLinksError.message);
+  }
+
+  const currentPhotos = collectPhotoRefs(
+    (currentLinks ?? []) as MomentPhotoLink[],
+  );
+  const currentPhotoIds = currentPhotos.idsByPath;
+
+  const storagePaths = normalizePhotoPaths(input.photos);
+  const nextPathSet = new Set(storagePaths);
+  const newPaths = storagePaths.filter((path) => !currentPhotoIds.has(path));
+  const removedLinks = Array.from(currentPhotoIds.entries()).filter(
+    ([path]) => !nextPathSet.has(path),
+  );
+  const removedPhotoIds = removedLinks.map(([, photoId]) => photoId);
+  const removedStoragePaths = removedLinks.map(([path]) => path);
+  const newPhotoIds = await insertPhotos(
+    input.groupId,
+    userId,
+    input.occurredAt,
+    newPaths,
+  );
+  const finalPhotoIds = storagePaths.map(
+    (path) => currentPhotoIds.get(path) ?? newPhotoIds.get(path),
+  );
+
+  if (finalPhotoIds.some((photoId) => !photoId)) {
+    throw new Error('Could not save all moment photos.');
+  }
+
+  const { error: deleteLinksError } = await supabase
+    .from('moment_photos')
+    .delete()
+    .eq('moment_id', input.momentId)
+    .eq('group_id', input.groupId);
+
+  if (deleteLinksError) {
+    throw new Error(deleteLinksError.message);
+  }
+
+  if (finalPhotoIds.length > 0) {
+    const { error: insertLinksError } = await supabase
+      .from('moment_photos')
+      .insert(
+        finalPhotoIds.map((photoId, index) => ({
+          group_id: input.groupId,
+          moment_id: input.momentId,
+          photo_id: photoId!,
+          sort_order: index,
+        })),
+      );
+
+    if (insertLinksError) {
+      throw new Error(insertLinksError.message);
+    }
+
+    const { error: updatePhotosError } = await supabase
+      .from('photos')
+      .update({ taken_at: input.occurredAt.toISOString() })
+      .in(
+        'id',
+        finalPhotoIds.filter((photoId): photoId is string => Boolean(photoId)),
+      );
+
+    if (updatePhotosError) {
+      throw new Error(updatePhotosError.message);
+    }
+  }
+
+  void cleanupPhotos(removedPhotoIds, removedStoragePaths);
+
+  return updatedMoment.id;
+}
+
+export async function deleteMoment(momentId: string, groupId: string) {
+  await requireCurrentUserId('You must be signed in to delete a moment.');
+
+  if (!momentId || !groupId) {
+    throw new Error('Moment not found.');
+  }
+
+  const { data: currentLinks, error: currentLinksError } = await supabase
+    .from('moment_photos')
+    .select('photo_id, photos(storage_path)')
+    .eq('moment_id', momentId)
+    .eq('group_id', groupId);
+
+  if (currentLinksError) {
+    throw new Error(currentLinksError.message);
+  }
+
+  const { photoIds, storagePaths } = collectPhotoRefs(
+    (currentLinks ?? []) as MomentPhotoLink[],
+  );
+
+  const { error: deleteLinksError } = await supabase
+    .from('moment_photos')
+    .delete()
+    .eq('moment_id', momentId)
+    .eq('group_id', groupId);
+
+  if (deleteLinksError) {
+    throw new Error(deleteLinksError.message);
+  }
+
+  const { error: deleteMomentError } = await supabase
+    .from('moments')
+    .delete()
+    .eq('id', momentId)
+    .eq('group_id', groupId);
+
+  if (deleteMomentError) {
+    throw new Error(deleteMomentError.message);
+  }
+
+  void cleanupPhotos(photoIds, storagePaths);
 }
 
 export async function getMomentById(
@@ -217,7 +502,7 @@ export async function getMomentById(
 
   const { data: links, error: linksError } = await supabase
     .from('moment_photos')
-    .select('sort_order, photos(storage_path)')
+    .select('sort_order, photo_id, photos(storage_path)')
     .eq('moment_id', momentId)
     .eq('group_id', groupId)
     .order('sort_order', { ascending: true });
@@ -226,9 +511,7 @@ export async function getMomentById(
     throw new Error(linksError.message);
   }
 
-  const storagePaths = (links ?? [])
-    .map((link) => resolvePhotoStoragePath(link.photos))
-    .filter((path): path is string => Boolean(path));
+  const { storagePaths } = collectPhotoRefs((links ?? []) as MomentPhotoLink[]);
 
   const signedUrls = await getSignedImageUrlMap(storagePaths);
 
@@ -239,7 +522,18 @@ export async function getMomentById(
     category: moment.category,
     occurredOn: moment.occurred_on,
     photos: storagePaths
-      .map((path) => signedUrls.get(path))
-      .filter((url): url is string => Boolean(url)),
+      .map((path) => {
+        const url = signedUrls.get(path);
+
+        if (!url) {
+          return null;
+        }
+
+        return {
+          storagePath: path,
+          url,
+        };
+      })
+      .filter((photo): photo is MomentDetailPhoto => Boolean(photo)),
   };
 }


### PR DESCRIPTION
Moments can now be edited and deleted without leaving the existing flow. The new route wiring reuses a shared form component for both create and edit, while the detail screen adds the actions needed to update or remove a moment. 

This also fills in the missing service and React Query mutations for updating and deleting moments, including keeping linked photos in sync and cleaning up removed photo records. The result is user-visible behavior, but the branch also reduces duplication by moving the form logic into one place instead of maintaining separate create and edit implementations.