### PR TITLE
Add header sign out menu and share popover UI

### DIFF
--- a/app/events/[id].tsx
+++ b/app/events/[id].tsx
@@ -3,6 +3,7 @@ import {
   type SelectedImage,
 } from '@/components/ui/AddImageField';
 import Divider from '@/components/ui/Divider';
+import PopoverMenu from '@/components/ui/PopoverMenu';
 import { Text } from '@/components/ui/Text';
 import { useActiveGroup } from '@/hooks/useActiveGroup';
 import {
@@ -28,7 +29,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
-  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -512,53 +512,26 @@ export default function EventDetailScreen() {
         </Pressable>
       </View>
 
-      <Modal
-        animationType="fade"
-        onRequestClose={() => setIsMenuOpen(false)}
-        transparent
+      <PopoverMenu
+        items={[
+          {
+            label: 'Edit event',
+            onPress: handleEdit,
+          },
+          {
+            label: isDeleting
+              ? 'Deleting...'
+              : isSavingPhotos
+                ? 'Saving photos...'
+                : 'Delete event',
+            onPress: handleDelete,
+            disabled: isMutatingEvent,
+            variant: 'danger',
+          },
+        ]}
+        onClose={() => setIsMenuOpen(false)}
         visible={isMenuOpen}
-      >
-        <View style={styles.menuOverlay}>
-          <Pressable
-            accessibilityRole="button"
-            onPress={() => setIsMenuOpen(false)}
-            style={styles.menuBackdrop}
-          />
-          <View style={styles.menuPanel}>
-            <Pressable
-              accessibilityRole="button"
-              onPress={handleEdit}
-              style={({ pressed }) => [
-                styles.menuAction,
-                pressed ? styles.menuActionPressed : null,
-              ]}
-            >
-              <Text style={styles.menuActionText}>Edit event</Text>
-            </Pressable>
-
-            <View style={styles.menuDivider} />
-
-            <Pressable
-              accessibilityRole="button"
-              disabled={isMutatingEvent}
-              onPress={handleDelete}
-              style={({ pressed }) => [
-                styles.menuAction,
-                pressed ? styles.menuActionPressed : null,
-                isMutatingEvent ? styles.menuActionDisabled : null,
-              ]}
-            >
-              <Text style={styles.menuActionDangerText}>
-                {isDeleting
-                  ? 'Deleting...'
-                  : isSavingPhotos
-                    ? 'Saving photos...'
-                    : 'Delete event'}
-              </Text>
-            </Pressable>
-          </View>
-        </View>
-      </Modal>
+      />
     </View>
   );
 }
@@ -721,49 +694,6 @@ const styles = StyleSheet.create({
     fontFamily: textTheme.family.medium,
     fontSize: textTheme.size.sm,
     lineHeight: textTheme.lineHeight.sm,
-  },
-  menuOverlay: {
-    flex: 1,
-  },
-  menuBackdrop: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  menuPanel: {
-    position: 'absolute',
-    right: space.lg,
-    top: space.lg + 84,
-    minWidth: 168,
-    backgroundColor: baseColors.bg,
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    borderColor: 'rgba(107, 101, 96, 0.16)',
-    overflow: 'hidden',
-  },
-  menuAction: {
-    paddingHorizontal: space.lg,
-    paddingVertical: space.md,
-  },
-  menuActionPressed: {
-    opacity: 0.82,
-  },
-  menuActionDisabled: {
-    opacity: 0.45,
-  },
-  menuActionText: {
-    color: baseColors.text,
-    fontFamily: textTheme.family.medium,
-    fontSize: textTheme.size.sm,
-    lineHeight: textTheme.lineHeight.sm,
-  },
-  menuActionDangerText: {
-    color: baseColors.textError,
-    fontFamily: textTheme.family.medium,
-    fontSize: textTheme.size.sm,
-    lineHeight: textTheme.lineHeight.sm,
-  },
-  menuDivider: {
-    height: 1,
-    backgroundColor: 'rgba(107, 101, 96, 0.12)',
   },
   errorText: {
     color: baseColors.textError,

--- a/app/moments/[id].tsx
+++ b/app/moments/[id].tsx
@@ -3,6 +3,7 @@ import {
   type SelectedImage,
 } from '@/components/ui/AddImageField';
 import Divider from '@/components/ui/Divider';
+import PopoverMenu from '@/components/ui/PopoverMenu';
 import { Text } from '@/components/ui/Text';
 import { useActiveGroup } from '@/hooks/useActiveGroup';
 import {
@@ -23,7 +24,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
-  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -503,49 +503,22 @@ export default function MomentDetailScreen() {
         </Pressable>
       </View>
 
-      <Modal
-        animationType="fade"
-        onRequestClose={() => setIsMenuOpen(false)}
-        transparent
+      <PopoverMenu
+        items={[
+          {
+            label: 'Edit moment',
+            onPress: handleEdit,
+          },
+          {
+            label: deleteActionLabel,
+            onPress: handleDelete,
+            disabled: isMutatingMoment,
+            variant: 'danger',
+          },
+        ]}
+        onClose={() => setIsMenuOpen(false)}
         visible={isMenuOpen}
-      >
-        <View style={styles.menuOverlay}>
-          <Pressable
-            accessibilityRole="button"
-            onPress={() => setIsMenuOpen(false)}
-            style={styles.menuBackdrop}
-          />
-          <View style={styles.menuPanel}>
-            <Pressable
-              accessibilityRole="button"
-              onPress={handleEdit}
-              style={({ pressed }) => [
-                styles.menuAction,
-                pressed ? styles.menuActionPressed : null,
-              ]}
-            >
-              <Text style={styles.menuActionText}>Edit moment</Text>
-            </Pressable>
-
-            <View style={styles.menuDivider} />
-
-            <Pressable
-              accessibilityRole="button"
-              disabled={isMutatingMoment}
-              onPress={handleDelete}
-              style={({ pressed }) => [
-                styles.menuAction,
-                pressed ? styles.menuActionPressed : null,
-                isMutatingMoment ? styles.menuActionDisabled : null,
-              ]}
-            >
-              <Text style={styles.menuActionDangerText}>
-                {deleteActionLabel}
-              </Text>
-            </Pressable>
-          </View>
-        </View>
-      </Modal>
+      />
     </View>
   );
 }
@@ -699,49 +672,6 @@ const styles = StyleSheet.create({
     fontFamily: textTheme.family.medium,
     fontSize: textTheme.size.sm,
     lineHeight: textTheme.lineHeight.sm,
-  },
-  menuOverlay: {
-    flex: 1,
-  },
-  menuBackdrop: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  menuPanel: {
-    backgroundColor: baseColors.bg,
-    borderColor: 'rgba(107, 101, 96, 0.16)',
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    minWidth: 168,
-    overflow: 'hidden',
-    position: 'absolute',
-    right: space.lg,
-    top: space.lg + 84,
-  },
-  menuAction: {
-    paddingHorizontal: space.lg,
-    paddingVertical: space.md,
-  },
-  menuActionPressed: {
-    opacity: 0.82,
-  },
-  menuActionDisabled: {
-    opacity: 0.45,
-  },
-  menuActionText: {
-    color: baseColors.text,
-    fontFamily: textTheme.family.medium,
-    fontSize: textTheme.size.sm,
-    lineHeight: textTheme.lineHeight.sm,
-  },
-  menuActionDangerText: {
-    color: baseColors.textError,
-    fontFamily: textTheme.family.medium,
-    fontSize: textTheme.size.sm,
-    lineHeight: textTheme.lineHeight.sm,
-  },
-  menuDivider: {
-    backgroundColor: 'rgba(107, 101, 96, 0.12)',
-    height: 1,
   },
   errorText: {
     color: baseColors.textError,

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -1,10 +1,14 @@
 import { GroupScopePicker } from '@/components/GroupScopePicker';
+import { signOut } from '@/lib/auth';
+import { radius } from '@/theme/radius';
+import PopoverMenu from '@/components/ui/PopoverMenu';
 import { Text } from '@/components/ui/Text';
 import { baseColors } from '@/theme/colors';
 import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
 import { CircleUser } from 'lucide-react-native';
-import { StyleSheet, View } from 'react-native';
+import { useState } from 'react';
+import { Alert, Pressable, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 interface HeaderProps {
@@ -17,6 +21,31 @@ interface HeaderProps {
 export const TAB_HEADER_CONTENT_HEIGHT = 108;
 
 export default function Header({ title, tagLine, color, height }: HeaderProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  async function handleSignOut() {
+    if (isSigningOut) {
+      return;
+    }
+
+    setIsSigningOut(true);
+
+    try {
+      await signOut();
+      setIsMenuOpen(false);
+    } catch (error) {
+      Alert.alert(
+        'Could not sign out',
+        error instanceof Error ? error.message : 'Please try again.',
+      );
+      setIsSigningOut(false);
+      return;
+    }
+
+    setIsSigningOut(false);
+  }
+
   return (
     <SafeAreaView
       edges={['top']}
@@ -37,11 +66,38 @@ export default function Header({ title, tagLine, color, height }: HeaderProps) {
               sheetTitle="Switch space"
               size="header"
             />
-            <CircleUser color={baseColors.text} size={24} />
+            <Pressable
+              accessibilityHint="Opens account actions"
+              accessibilityLabel="Open account menu"
+              accessibilityRole="button"
+              disabled={isSigningOut}
+              onPress={() => setIsMenuOpen(true)}
+              style={({ pressed }) => [
+                styles.accountButton,
+                pressed ? styles.accountButtonPressed : null,
+                isSigningOut ? styles.accountButtonDisabled : null,
+              ]}
+            >
+              <CircleUser color={baseColors.text} size={24} />
+            </Pressable>
           </View>
         </View>
         {tagLine && <Text style={styles.tagLine}>{tagLine}</Text>}
       </View>
+
+      <PopoverMenu
+        dismissDisabled={isSigningOut}
+        items={[
+          {
+            label: isSigningOut ? 'Signing out...' : 'Sign out',
+            onPress: handleSignOut,
+            disabled: isSigningOut,
+            variant: 'danger',
+          },
+        ]}
+        onClose={() => setIsMenuOpen(false)}
+        visible={isMenuOpen}
+      />
     </SafeAreaView>
   );
 }
@@ -71,6 +127,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     gap: space.sm,
+  },
+  accountButton: {
+    alignItems: 'center',
+    borderRadius: radius.full,
+    justifyContent: 'center',
+  },
+  accountButtonPressed: {
+    opacity: 0.82,
+  },
+  accountButtonDisabled: {
+    opacity: 0.45,
   },
   tagLine: {
     color: baseColors.textSoft,

--- a/components/ui/PopoverMenu.tsx
+++ b/components/ui/PopoverMenu.tsx
@@ -1,0 +1,122 @@
+import { Text } from '@/components/ui/Text';
+import { baseColors } from '@/theme/colors';
+import { radius } from '@/theme/radius';
+import { space } from '@/theme/space';
+import { text as textTheme } from '@/theme/type';
+import { Modal, Pressable, StyleSheet, View } from 'react-native';
+
+type PopoverMenuItem = {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  variant?: 'default' | 'danger';
+};
+
+type PopoverMenuProps = {
+  visible: boolean;
+  onClose: () => void;
+  items: PopoverMenuItem[];
+  dismissDisabled?: boolean;
+};
+
+export default function PopoverMenu({
+  visible,
+  onClose,
+  items,
+  dismissDisabled = false,
+}: PopoverMenuProps) {
+  return (
+    <Modal
+      animationType="fade"
+      onRequestClose={() => {
+        if (!dismissDisabled) {
+          onClose();
+        }
+      }}
+      transparent
+      visible={visible}
+    >
+      <View style={styles.overlay}>
+        <Pressable
+          accessibilityRole="button"
+          disabled={dismissDisabled}
+          onPress={onClose}
+          style={styles.backdrop}
+        />
+        <View style={styles.panel}>
+          {items.map((item, index) => (
+            <View key={item.label}>
+              {index > 0 ? <View style={styles.divider} /> : null}
+              <Pressable
+                accessibilityRole="button"
+                disabled={item.disabled}
+                onPress={item.onPress}
+                style={({ pressed }) => [
+                  styles.action,
+                  pressed ? styles.actionPressed : null,
+                  item.disabled ? styles.actionDisabled : null,
+                ]}
+              >
+                <Text
+                  style={
+                    item.variant === 'danger'
+                      ? styles.actionDangerText
+                      : styles.actionText
+                  }
+                >
+                  {item.label}
+                </Text>
+              </Pressable>
+            </View>
+          ))}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  panel: {
+    backgroundColor: baseColors.bg,
+    borderColor: 'rgba(107, 101, 96, 0.16)',
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    minWidth: 168,
+    overflow: 'hidden',
+    position: 'absolute',
+    right: space.lg,
+    top: space.lg + 84,
+  },
+  action: {
+    paddingHorizontal: space.lg,
+    paddingVertical: space.md,
+  },
+  actionPressed: {
+    opacity: 0.82,
+  },
+  actionDisabled: {
+    opacity: 0.45,
+  },
+  actionText: {
+    color: baseColors.text,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  actionDangerText: {
+    color: baseColors.textError,
+    fontFamily: textTheme.family.medium,
+    fontSize: textTheme.size.sm,
+    lineHeight: textTheme.lineHeight.sm,
+  },
+  divider: {
+    backgroundColor: 'rgba(107, 101, 96, 0.12)',
+    height: 1,
+  },
+});


### PR DESCRIPTION
This adds a sign out action to the account menu in the tab header, so the header user icon now opens a small menu with the new sign out flow.

The same popover menu is now shared with the event and moment detail screens, which keeps the styling and wiring in one place and makes the code easier to follow.