### PR TITLE
Add db connection to timeline and memories

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,111 +1,73 @@
 import { Card } from '@/components/ui/Card';
+import { Text } from '@/components/ui/Text';
+import { useActiveGroup } from '@/hooks/useActiveGroup';
+import { useTimelineItemsQuery } from '@/hooks/useTimelineItems';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
-import { Link } from 'expo-router';
-import { ScrollView, StyleSheet, View } from 'react-native';
-interface MemoryItem {
-  id: number;
-  title: string;
-  date: string;
-  imageUrl: string;
-  description: string;
-  type?: string;
+import { type Href, Link } from 'expo-router';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
+
+const FALLBACK_COVER_IMAGE = require('@/assets/images/fallbackImage.png');
+
+function formatOccurredOn(dateValue: string): string {
+  const date = new Date(dateValue);
+
+  if (Number.isNaN(date.getTime())) {
+    return dateValue;
+  }
+
+  return date.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function resolveTimelineHref(item: {
+  kind?: 'event' | 'moment' | null;
+  sourceId?: string;
+}): Href | null {
+  if (!item.sourceId) {
+    return null;
+  }
+
+  if (item.kind === 'event') {
+    return `/events/${item.sourceId}` as Href;
+  }
+
+  if (item.kind === 'moment') {
+    return `/moments/${item.sourceId}` as Href;
+  }
+
+  return null;
 }
 
 export default function TimelineScreen() {
+  const {
+    activeGroup,
+    errorMessage: groupError,
+    isLoading: isLoadingGroups,
+  } = useActiveGroup();
+  const timelineQuery = useTimelineItemsQuery(activeGroup?.id);
   const pageColor = sectionColors.timeline;
-  const memories: MemoryItem[] = [
-    {
-      id: 1,
-      title: 'Beach Vacation',
-      date: 'June 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      type: 'Special Moment',
-    },
-    {
-      id: 2,
-      title: 'Mountain Hike',
-      date: 'September 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1500534623283-312aade485b7?auto=format&fit=crop&w=800&q=80',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      type: 'Special Moment',
-    },
-    {
-      id: 3,
-      title: 'City Exploration',
-      date: 'December 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=800&q=80',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      type: 'Special Moment',
-    },
-    {
-      id: 4,
-      title: 'Forest Camping',
-      date: 'April 2024',
-      imageUrl:
-        'https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=800&q=80',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      type: 'Special Moment',
-    },
-    {
-      id: 5,
-      title: 'Desert Road Trip',
-      date: 'August 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=80',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      type: 'Special Moment',
-    },
-    {
-      id: 6,
-      title: 'Snowy Getaway',
-      date: 'January 2024',
-      imageUrl:
-        'https://images.unsplash.com/photo-1519608487953-e999c86e7455?auto=format&fit=crop&w=800&q=80',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      type: 'Special Moment',
-    },
-    {
-      id: 7,
-      title: 'Lakeside Retreat',
-      date: 'May 2024',
-      imageUrl:
-        'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      type: 'Special Moment',
-    },
-    {
-      id: 8,
-      title: 'Countryside Picnic',
-      date: 'July 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1500534623283-312aade485b7?auto=format&fit=crop&w=800&q=80',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      type: 'Special Moment',
-    },
-    {
-      id: 9,
-      title: 'Urban Art Tour',
-      date: 'November 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=800&q=80',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      type: 'Special Moment',
-    },
-  ];
+  const timelineItems = timelineQuery.data ?? [];
+  const loadError =
+    groupError ??
+    (timelineQuery.error instanceof Error
+      ? timelineQuery.error.message
+      : timelineQuery.error
+        ? 'Failed to load timeline items.'
+        : null);
+  const activeGroupLabel =
+    activeGroup?.groupKind === 'personal'
+      ? 'Personal'
+      : (activeGroup?.name ?? 'this space');
 
   return (
     <ScrollView
@@ -116,22 +78,57 @@ export default function TimelineScreen() {
       <View style={styles.container}>
         <View style={styles.timeline}></View>
         <View style={[styles.memoriesContainer]}>
-          {memories.map((memory) => (
-            <View style={{ position: 'relative' }} key={memory.id}>
-              <View style={styles.indicator}></View>
-              <Link href={`/moments#${memory.id}`} asChild>
-                <Card
-                  variant="default"
-                  title={memory.title}
-                  date={memory.date}
-                  coverImage={memory.imageUrl}
-                  color={pageColor}
-                  description={memory.description}
-                  type={memory.type}
-                />
-              </Link>
-            </View>
-          ))}
+          {isLoadingGroups || timelineQuery.isPending ? (
+            <ActivityIndicator color={sectionColors.timeline} />
+          ) : null}
+
+          {!isLoadingGroups && !timelineQuery.isPending && loadError ? (
+            <Text style={styles.errorText}>{loadError}</Text>
+          ) : null}
+
+          {!isLoadingGroups &&
+          !timelineQuery.isPending &&
+          !loadError &&
+          timelineItems.length === 0 ? (
+            <Text style={styles.emptyText}>
+              No timeline items in {activeGroupLabel} yet.
+            </Text>
+          ) : null}
+
+          {!isLoadingGroups && !timelineQuery.isPending && !loadError
+            ? timelineItems.map((item) => {
+                const href = resolveTimelineHref(item);
+                const card = (
+                  <Card
+                    variant="default"
+                    title={item.title}
+                    date={formatOccurredOn(item.occurredOn)}
+                    coverImage={item.coverImage ?? FALLBACK_COVER_IMAGE}
+                    color={pageColor}
+                    description={item.description}
+                    type={item.displayType}
+                  />
+                );
+
+                return (
+                  <View style={styles.itemWrap} key={item.id}>
+                    <View style={styles.indicator}></View>
+                    {href ? (
+                      <Link asChild href={href}>
+                        <Pressable
+                          accessibilityHint="Opens this timeline item"
+                          accessibilityRole="button"
+                        >
+                          {card}
+                        </Pressable>
+                      </Link>
+                    ) : (
+                      card
+                    )}
+                  </View>
+                );
+              })
+            : null}
         </View>
       </View>
     </ScrollView>
@@ -144,7 +141,7 @@ const styles = StyleSheet.create({
     backgroundColor: baseColors.bg,
   },
   content: {
-    paddingVertical: space.xl,
+    paddingBottom: space.xl,
     paddingHorizontal: space.xl,
   },
   timeline: {
@@ -180,4 +177,17 @@ const styles = StyleSheet.create({
     gap: space.lg,
     width: '100%',
   },
+  itemWrap: {
+    position: 'relative',
+    width: '100%',
+  },
+  emptyText: {
+    color: baseColors.textSoft,
+    textAlign: 'center',
+  },
+  errorText: {
+    color: baseColors.textError,
+    textAlign: 'center',
+  },
+  link: {},
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -76,7 +76,9 @@ export default function TimelineScreen() {
       showsVerticalScrollIndicator={false}
     >
       <View style={styles.container}>
-        <View style={styles.timeline}></View>
+        {!isLoadingGroups && !timelineQuery.isPending && !loadError ? (
+          <View style={styles.timeline}></View>
+        ) : null}
         <View style={[styles.memoriesContainer]}>
           {isLoadingGroups || timelineQuery.isPending ? (
             <ActivityIndicator color={sectionColors.timeline} />

--- a/app/(tabs)/memories.tsx
+++ b/app/(tabs)/memories.tsx
@@ -262,7 +262,7 @@ function Modal({
 const styles = StyleSheet.create({
   content: {
     paddingHorizontal: space.lg,
-    paddingVertical: space.xl,
+    paddingBottom: space.xl,
   },
   container: {
     flex: 1,

--- a/app/(tabs)/memories.tsx
+++ b/app/(tabs)/memories.tsx
@@ -1,17 +1,20 @@
 import Button from '@/components/ui/Button';
 import Image from '@/components/ui/Image';
+import { Text } from '@/components/ui/Text';
+import { useActiveGroup } from '@/hooks/useActiveGroup';
+import { useMemoryWallQuery } from '@/hooks/useMemoryWall';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
 import { text } from '@/theme/type';
 import { Image as ExpoImage } from 'expo-image';
-import { navigate } from 'expo-router/build/global-state/routing';
-import { useState } from 'react';
+import { Link, type Href } from 'expo-router';
+import { useMemo, useState } from 'react';
 import {
+  ActivityIndicator,
   Modal as ExpoModal,
   Pressable,
   ScrollView,
   StyleSheet,
-  Text,
   useWindowDimensions,
   View,
 } from 'react-native';
@@ -22,10 +25,14 @@ const COLUMNS = 2;
 type MemoryType = 'moment' | 'event' | 'chapter';
 
 interface MemoryItem {
-  id: number;
+  id: string;
+  sourceId: string;
+  eventId?: string;
+  momentId?: string;
   title: string;
   date: string;
-  imageUrl: string;
+  imageUrl: string | number;
+  description: string;
   type: MemoryType;
 }
 
@@ -34,81 +41,92 @@ const MEMORY_TYPE_COLORS: Record<MemoryType, string> = {
   event: sectionColors.events,
   chapter: sectionColors.chapters,
 };
+
+const FALLBACK_COVER_IMAGE = require('@/assets/images/fallbackImage.png');
+
+function formatOccurredOn(dateValue: string): string {
+  const date = new Date(dateValue);
+
+  if (Number.isNaN(date.getTime())) {
+    return dateValue;
+  }
+
+  return date.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function shuffleItems<T>(items: T[]): T[] {
+  const copy = [...items];
+
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+    [copy[index], copy[randomIndex]] = [copy[randomIndex], copy[index]];
+  }
+
+  return copy;
+}
+
+function resolveMemoryHref(item: {
+  type?: MemoryType | null;
+  sourceId?: string;
+  eventId?: string;
+  momentId?: string;
+}): Href | null {
+  if (item.eventId) {
+    return `/events/${item.eventId}` as Href;
+  }
+
+  if (item.momentId) {
+    return `/moments/${item.momentId}` as Href;
+  }
+
+  if (!item.sourceId) {
+    return null;
+  }
+
+  if (item.type === 'event') {
+    return `/events/${item.sourceId}` as Href;
+  }
+
+  if (item.type === 'moment') {
+    return `/moments/${item.sourceId}` as Href;
+  }
+
+  return null;
+}
+
 export default function MemoriesScreen() {
-  const memories: MemoryItem[] = [
-    {
-      id: 1,
-      title: 'Beach Vacation',
-      date: 'June 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80',
-      type: 'moment',
-    },
-    {
-      id: 2,
-      title: 'Mountain Hike',
-      date: 'September 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1500534623283-312aade485b7?auto=format&fit=crop&w=800&q=80',
-      type: 'event',
-    },
-    {
-      id: 3,
-      title: 'City Exploration',
-      date: 'December 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=800&q=80',
-      type: 'chapter',
-    },
-    {
-      id: 4,
-      title: 'Forest Camping',
-      date: 'April 2024',
-      imageUrl:
-        'https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=800&q=80',
-      type: 'moment',
-    },
-    {
-      id: 5,
-      title: 'Desert Road Trip',
-      date: 'August 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=80',
-      type: 'event',
-    },
-    {
-      id: 6,
-      title: 'Snowy Getaway',
-      date: 'January 2024',
-      imageUrl:
-        'https://images.unsplash.com/photo-1519608487953-e999c86e7455?auto=format&fit=crop&w=800&q=80',
-      type: 'chapter',
-    },
-    {
-      id: 7,
-      title: 'Lakeside Retreat',
-      date: 'May 2024',
-      imageUrl:
-        'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80',
-      type: 'moment',
-    },
-    {
-      id: 8,
-      title: 'Countryside Picnic',
-      date: 'July 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1500534623283-312aade485b7?auto=format&fit=crop&w=800&q=80',
-      type: 'event',
-    },
-    {
-      id: 9,
-      title: 'Urban Art Tour',
-      date: 'November 2023',
-      imageUrl:
-        'https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=800&q=80',
-      type: 'chapter',
-    },
-  ];
+  const {
+    activeGroup,
+    errorMessage: groupError,
+    isLoading: isLoadingGroups,
+  } = useActiveGroup();
+  const memoryWallQuery = useMemoryWallQuery(activeGroup?.id);
+  const memories: MemoryItem[] = useMemo(() => {
+    const mappedItems = (memoryWallQuery.data ?? []).map((item) => ({
+      id: item.id,
+      sourceId: item.sourceId,
+      eventId: item.eventId,
+      momentId: item.momentId,
+      title: item.title,
+      date: formatOccurredOn(item.occurredOn),
+      imageUrl: item.imageUrl ?? FALLBACK_COVER_IMAGE,
+      description: item.description,
+      type: item.type,
+    }));
+
+    return shuffleItems(mappedItems);
+  }, [memoryWallQuery.data]);
+  const loadError =
+    groupError ??
+    (memoryWallQuery.error instanceof Error
+      ? memoryWallQuery.error.message
+      : memoryWallQuery.error
+        ? 'Failed to load memories.'
+        : null);
 
   const { width } = useWindowDimensions();
   const horizontalPadding = space.lg * 2; // same as your container paddingHorizontal
@@ -129,6 +147,22 @@ export default function MemoriesScreen() {
 
       <View style={styles.container}>
         <Text style={styles.title}>✦ {memories.length} memories ✦</Text>
+
+        {isLoadingGroups || memoryWallQuery.isPending ? (
+          <ActivityIndicator color={sectionColors.memories} />
+        ) : null}
+
+        {!isLoadingGroups && !memoryWallQuery.isPending && loadError ? (
+          <Text style={styles.errorText}>{loadError}</Text>
+        ) : null}
+
+        {!isLoadingGroups &&
+        !memoryWallQuery.isPending &&
+        !loadError &&
+        memories.length === 0 ? (
+          <Text style={styles.emptyText}>No memories yet in this space.</Text>
+        ) : null}
+
         <View
           style={[
             styles.memoriesContainer,
@@ -168,6 +202,9 @@ function Modal({
   setModalVisible: (visible: boolean) => void;
   selectedMemory: MemoryItem | null;
 }) {
+  const href = selectedMemory ? resolveMemoryHref(selectedMemory) : null;
+
+  console.log('Selected Memory:', selectedMemory);
   return (
     <ExpoModal
       animationType="fade"
@@ -186,36 +223,34 @@ function Modal({
           onPress={(event) => event.stopPropagation()}
         >
           <ExpoImage
-            source={{
-              uri:
-                selectedMemory?.imageUrl ||
-                'https://via.placeholder.com/600x400',
-            }}
+            source={
+              typeof selectedMemory?.imageUrl === 'string'
+                ? { uri: selectedMemory.imageUrl }
+                : (selectedMemory?.imageUrl ?? FALLBACK_COVER_IMAGE)
+            }
             style={[styles.modalImage]}
           />
           <View style={{ alignItems: 'center', gap: space.xxs }}>
-            <Text style={styles.modalTextTitle}>{selectedMemory?.title}</Text>
-            <Text style={styles.modalTextDate}>
-              {selectedMemory?.date || 'Unknown Date'}
+            <Text numberOfLines={1} style={styles.modalTextTitle}>
+              {selectedMemory?.title}
+            </Text>
+            <Text style={styles.modalTextDate}>{selectedMemory?.date}</Text>
+
+            <Text numberOfLines={2} style={styles.modalTextDescription}>
+              {selectedMemory?.description}
             </Text>
           </View>
-          <Button
-            color={
-              MEMORY_TYPE_COLORS[
-                (selectedMemory?.type as MemoryType) || 'moments'
-              ]
-            }
-            variant="default"
-            label={`See ${selectedMemory?.type as MemoryType}`}
-            onPress={() => {
-              navigate(
-                `/${selectedMemory?.type as MemoryType}s#${selectedMemory?.id}`,
-              );
-              setModalVisible(false);
-            }}
-            // Handle see memory action, e.g., navigate to detail screen
-          />
+
+          <Link asChild href={href ? href : '/+not-found'}>
+            <Button
+              color={MEMORY_TYPE_COLORS[selectedMemory?.type ?? 'moment']}
+              variant="default"
+              label={`See ${selectedMemory?.type as MemoryType}`}
+              onPress={() => setModalVisible(false)}
+            />
+          </Link>
         </Pressable>
+
         <View>
           <Text style={styles.closeButton}>Click anywhere to close</Text>
         </View>
@@ -257,14 +292,8 @@ const styles = StyleSheet.create({
 
   modalView: {
     maxWidth: 360,
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
+    boxShadow: `0px 4px 12px 0px ${baseColors.bg}`,
     height: 'auto',
-    shadowOpacity: 0.25,
-    shadowRadius: 4,
     elevation: 5,
     width: '100%',
     backgroundColor: baseColors.text,
@@ -283,14 +312,32 @@ const styles = StyleSheet.create({
   },
 
   modalTextTitle: {
+    color: baseColors.bg,
     fontFamily: text.family.semiBold,
-    lineHeight: text.lineHeight.xl,
-    fontSize: text.size.xl,
+    lineHeight: text.lineHeight.lg,
+    fontSize: text.size.lg,
   },
   modalTextDate: {
+    color: baseColors.textSoft,
     fontSize: text.size.xs,
     lineHeight: text.lineHeight.xs,
     fontFamily: text.family.mediumItalic,
+  },
+  modalTextDescription: {
+    color: baseColors.textMuted,
+    fontFamily: text.family.regular,
+    fontSize: text.size.sm,
+    lineHeight: text.lineHeight.sm,
+    textAlign: 'center',
+  },
+
+  emptyText: {
+    color: baseColors.textSoft,
+    textAlign: 'center',
+  },
+  errorText: {
+    color: baseColors.textError,
+    textAlign: 'center',
   },
 
   closeButton: {

--- a/app/(tabs)/memories.tsx
+++ b/app/(tabs)/memories.tsx
@@ -146,7 +146,9 @@ export default function MemoriesScreen() {
       />
 
       <View style={styles.container}>
-        <Text style={styles.title}>✦ {memories.length} memories ✦</Text>
+        {!isLoadingGroups && !memoryWallQuery.isPending && !loadError && (
+          <Text style={styles.title}>✦ {memories.length} memories ✦</Text>
+        )}
 
         {isLoadingGroups || memoryWallQuery.isPending ? (
           <ActivityIndicator color={sectionColors.memories} />

--- a/components/ui/Image.tsx
+++ b/components/ui/Image.tsx
@@ -6,7 +6,7 @@ import Chip from './Chip';
 import { Text } from './Text';
 
 interface ImageProps {
-  source: string;
+  source: string | number;
   variant?: 'default' | 'large' | 'polaroid';
   chip?: {
     label: string;
@@ -16,6 +16,14 @@ interface ImageProps {
     color: string;
     date: string;
   };
+}
+
+function resolveImageSource(source: string | number) {
+  if (typeof source === 'string') {
+    return { uri: source };
+  }
+
+  return source;
 }
 
 export default function Image({
@@ -37,15 +45,19 @@ export default function Image({
 }
 
 function DefaultImage({ source }: ImageProps) {
+  const imageSource = resolveImageSource(source);
+
   return (
-    <ExpoImage source={{ uri: source }} style={styles.imageContainerDefault} />
+    <ExpoImage source={imageSource} style={styles.imageContainerDefault} />
   );
 }
 
 function LargeImage({ source, chip }: ImageProps) {
+  const imageSource = resolveImageSource(source);
+
   return (
     <View style={styles.imageContainerLarge}>
-      <ExpoImage source={{ uri: source }} style={styles.imageLarge} />
+      <ExpoImage source={imageSource} style={styles.imageLarge} />
       <Chip
         style={styles.chip}
         isSelected
@@ -57,6 +69,8 @@ function LargeImage({ source, chip }: ImageProps) {
 }
 
 function PolaroidImage({ source, polaroid }: ImageProps) {
+  const imageSource = resolveImageSource(source);
+
   let randomRotation = Math.random() * 10 - 5; // Random rotation between -5 and 5 degrees
   let pinOffset = 175 / 2 - 8; // Center the pin based on the image width and pin size
   return (
@@ -68,7 +82,7 @@ function PolaroidImage({ source, polaroid }: ImageProps) {
         },
       ]}
     >
-      <ExpoImage source={{ uri: source }} style={styles.imagePolaroid} />
+      <ExpoImage source={imageSource} style={styles.imagePolaroid} />
       <View
         style={[
           styles.pin,

--- a/hooks/useMemoryWall.ts
+++ b/hooks/useMemoryWall.ts
@@ -1,0 +1,17 @@
+import { listMemoryWallForGroup } from '@/services/memoryWall';
+import { useQuery } from '@tanstack/react-query';
+
+export const memoryWallKeys = {
+  all: ['memory-wall'] as const,
+  lists: () => [...memoryWallKeys.all, 'list'] as const,
+  list: (groupId: string | null) =>
+    [...memoryWallKeys.lists(), groupId ?? 'no-group'] as const,
+};
+
+export function useMemoryWallQuery(groupId?: string | null) {
+  return useQuery({
+    queryKey: memoryWallKeys.list(groupId ?? null),
+    queryFn: () =>
+      groupId ? listMemoryWallForGroup(groupId) : Promise.resolve([]),
+  });
+}

--- a/hooks/useTimelineItems.ts
+++ b/hooks/useTimelineItems.ts
@@ -1,0 +1,17 @@
+import { listTimelineItemsForGroup } from '@/services/timelineItems';
+import { useQuery } from '@tanstack/react-query';
+
+export const timelineKeys = {
+  all: ['timeline-items'] as const,
+  lists: () => [...timelineKeys.all, 'list'] as const,
+  list: (groupId: string | null) =>
+    [...timelineKeys.lists(), groupId ?? 'no-group'] as const,
+};
+
+export function useTimelineItemsQuery(groupId?: string | null) {
+  return useQuery({
+    queryKey: timelineKeys.list(groupId ?? null),
+    queryFn: () =>
+      groupId ? listTimelineItemsForGroup(groupId) : Promise.resolve([]),
+  });
+}

--- a/services/memoryWall.ts
+++ b/services/memoryWall.ts
@@ -1,0 +1,541 @@
+import { getSignedImageUrlMap } from '@/lib/images';
+import { supabase } from '@/lib/supabase';
+import {
+  getCurrentUserId,
+  type JoinedPhoto,
+  resolvePhotoStoragePath,
+} from '@/services/userContext';
+
+type MemoryWallRow = Record<string, unknown>;
+
+export type MemoryWallType = 'moment' | 'event' | 'chapter';
+
+export type MemoryWallItem = {
+  id: string;
+  sourceId: string;
+  eventId?: string;
+  momentId?: string;
+  title: string;
+  description: string;
+  occurredOn: string;
+  type: MemoryWallType;
+  imageUrl?: string;
+};
+
+type EventPhotoLink = {
+  event_id?: string | null;
+  photos?: JoinedPhoto;
+};
+
+type MomentPhotoLink = {
+  moment_id?: string | null;
+  photos?: JoinedPhoto;
+};
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => toNonEmptyString(item))
+    .filter((item): item is string => Boolean(item));
+}
+
+function randomItem<T>(items: T[]): T | undefined {
+  if (items.length === 0) {
+    return undefined;
+  }
+
+  const index = Math.floor(Math.random() * items.length);
+  return items[index];
+}
+
+function normalizeType(value: string | null): MemoryWallType | null {
+  const lowered = value?.toLowerCase() ?? '';
+
+  if (!lowered) {
+    return null;
+  }
+
+  if (lowered.includes('event')) {
+    return 'event';
+  }
+
+  if (lowered.includes('moment')) {
+    return 'moment';
+  }
+
+  if (lowered.includes('chapter')) {
+    return 'chapter';
+  }
+
+  if (lowered.includes('milestone')) {
+    return 'chapter';
+  }
+
+  return null;
+}
+
+function pickTypeHint(row: MemoryWallRow): MemoryWallType | null {
+  if (toNonEmptyString(row.event_id)) {
+    return 'event';
+  }
+
+  if (toNonEmptyString(row.moment_id)) {
+    return 'moment';
+  }
+
+  if (toNonEmptyString(row.chapter_id)) {
+    return 'chapter';
+  }
+
+  const candidate =
+    toNonEmptyString(row.source_table) ??
+    toNonEmptyString(row.table_name) ??
+    toNonEmptyString(row.entity_table) ??
+    toNonEmptyString(row.source_item_type) ??
+    toNonEmptyString(row.entity_type) ??
+    toNonEmptyString(row.source_type) ??
+    toNonEmptyString(row.item_type) ??
+    toNonEmptyString(row.item_kind) ??
+    toNonEmptyString(row.kind) ??
+    toNonEmptyString(row.type);
+
+  return normalizeType(candidate);
+}
+
+function normalizeDate(value: unknown): string {
+  const raw = toNonEmptyString(value) ?? '';
+
+  if (!raw) {
+    return '';
+  }
+
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? raw : date.toISOString();
+}
+
+function pickRowImageCandidates(row: MemoryWallRow): string[] {
+  const inline = [
+    toNonEmptyString(row.image_url),
+    toNonEmptyString(row.cover_image_url),
+    toNonEmptyString(row.photo_url),
+    toNonEmptyString(row.storage_path),
+    toNonEmptyString(row.image),
+    toNonEmptyString(row.cover_image),
+  ].filter((item): item is string => Boolean(item));
+
+  const arrays = [
+    ...toStringArray(row.image_urls),
+    ...toStringArray(row.photo_urls),
+    ...toStringArray(row.storage_paths),
+    ...toStringArray(row.images),
+    ...toStringArray(row.photos),
+  ];
+
+  return [...inline, ...arrays];
+}
+
+function normalizeStoragePath(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return null;
+  }
+
+  const withoutLeadingSlash = trimmed.startsWith('/')
+    ? trimmed.slice(1)
+    : trimmed;
+  return withoutLeadingSlash;
+}
+
+function pickSourceId(
+  row: MemoryWallRow,
+  typeHint: MemoryWallType | null,
+): string {
+  const eventId = toNonEmptyString(row.event_id);
+  const momentId = toNonEmptyString(row.moment_id);
+  const chapterId = toNonEmptyString(row.chapter_id);
+
+  if (typeHint === 'event' && eventId) {
+    return eventId;
+  }
+
+  if (typeHint === 'moment' && momentId) {
+    return momentId;
+  }
+
+  if (typeHint === 'chapter' && chapterId) {
+    return chapterId;
+  }
+
+  return (
+    eventId ??
+    momentId ??
+    chapterId ??
+    toNonEmptyString(row.source_item_id) ??
+    toNonEmptyString(row.entity_id) ??
+    toNonEmptyString(row.source_id) ??
+    toNonEmptyString(row.item_id) ??
+    toNonEmptyString(row.id) ??
+    ''
+  );
+}
+
+export async function listMemoryWallForGroup(
+  groupId: string,
+): Promise<MemoryWallItem[]> {
+  const userId = await getCurrentUserId();
+
+  if (!userId || !groupId) {
+    return [];
+  }
+
+  const { data, error } = await supabase.from('memory_wall').select('*');
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const rows = ((data ?? []) as MemoryWallRow[]).filter((row) => {
+    const rowGroupId = toNonEmptyString(row.group_id);
+    return !rowGroupId || rowGroupId === groupId;
+  });
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const baseItems = rows
+    .map((row) => {
+      const typeHint = pickTypeHint(row);
+      const sourceId = pickSourceId(row, typeHint);
+      const eventId = toNonEmptyString(row.event_id) ?? undefined;
+      const momentId = toNonEmptyString(row.moment_id) ?? undefined;
+      const title =
+        toNonEmptyString(row.title) ??
+        toNonEmptyString(row.name) ??
+        'Untitled memory';
+      const description =
+        toNonEmptyString(row.description) ??
+        toNonEmptyString(row.notes) ??
+        toNonEmptyString(row.summary) ??
+        '';
+
+      return {
+        id: toNonEmptyString(row.id) ?? sourceId,
+        sourceId,
+        eventId,
+        momentId,
+        title,
+        description,
+        occurredOn: normalizeDate(
+          row.occurred_on ?? row.occurred_at ?? row.date ?? row.created_at,
+        ),
+        typeHint,
+        imageCandidates: pickRowImageCandidates(row),
+      };
+    })
+    .filter((item) => Boolean(item.id));
+
+  const candidateSourceIds = Array.from(
+    new Set(baseItems.map((item) => item.sourceId).filter(Boolean)),
+  );
+
+  const [eventLinksResult, momentLinksResult] = await Promise.all([
+    candidateSourceIds.length > 0
+      ? supabase
+          .from('event_photos')
+          .select('event_id, photos(storage_path)')
+          .in('event_id', candidateSourceIds)
+      : Promise.resolve({ data: [], error: null }),
+    candidateSourceIds.length > 0
+      ? supabase
+          .from('moment_photos')
+          .select('moment_id, photos(storage_path)')
+          .in('moment_id', candidateSourceIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  if (eventLinksResult.error) {
+    throw new Error(eventLinksResult.error.message);
+  }
+
+  if (momentLinksResult.error) {
+    throw new Error(momentLinksResult.error.message);
+  }
+
+  const randomPathBySourceId = new Map<string, string>();
+
+  const eventPathsById = new Map<string, string[]>();
+  for (const link of (eventLinksResult.data ?? []) as EventPhotoLink[]) {
+    if (!link.event_id) {
+      continue;
+    }
+
+    const storagePath = resolvePhotoStoragePath(link.photos);
+    if (!storagePath) {
+      continue;
+    }
+
+    const paths = eventPathsById.get(link.event_id) ?? [];
+    paths.push(storagePath);
+    eventPathsById.set(link.event_id, paths);
+  }
+
+  const momentPathsById = new Map<string, string[]>();
+  for (const link of (momentLinksResult.data ?? []) as MomentPhotoLink[]) {
+    if (!link.moment_id) {
+      continue;
+    }
+
+    const storagePath = resolvePhotoStoragePath(link.photos);
+    if (!storagePath) {
+      continue;
+    }
+
+    const paths = momentPathsById.get(link.moment_id) ?? [];
+    paths.push(storagePath);
+    momentPathsById.set(link.moment_id, paths);
+  }
+
+  for (const [sourceId, paths] of eventPathsById) {
+    const picked = randomItem(paths);
+    if (picked) {
+      randomPathBySourceId.set(sourceId, picked);
+    }
+  }
+
+  for (const [sourceId, paths] of momentPathsById) {
+    const picked = randomItem(paths);
+    if (picked) {
+      randomPathBySourceId.set(sourceId, picked);
+    }
+  }
+
+  const allPathsToSign = new Set<string>();
+  for (const item of baseItems) {
+    const linkedPath = randomPathBySourceId.get(item.sourceId);
+    const rowPath = randomItem(
+      item.imageCandidates.filter(
+        (value) =>
+          !value.startsWith('http://') && !value.startsWith('https://'),
+      ),
+    );
+
+    if (linkedPath) {
+      allPathsToSign.add(linkedPath);
+    }
+
+    if (rowPath) {
+      allPathsToSign.add(rowPath);
+    }
+  }
+
+  const signedUrls = await getSignedImageUrlMap(Array.from(allPathsToSign));
+
+  const storagePaths = Array.from(
+    new Set(
+      baseItems
+        .map((item) => randomItem(item.imageCandidates) ?? '')
+        .filter(Boolean),
+    ),
+  );
+
+  const [eventPhotosLookupResult, momentPhotosLookupResult] = await Promise.all(
+    [
+      storagePaths.length > 0
+        ? supabase
+            .from('event_photos')
+            .select('event_id, photos(storage_path)')
+            .limit(1000)
+        : Promise.resolve({ data: [], error: null }),
+      storagePaths.length > 0
+        ? supabase
+            .from('moment_photos')
+            .select('moment_id, photos(storage_path)')
+            .limit(1000)
+        : Promise.resolve({ data: [], error: null }),
+    ],
+  );
+
+  if (eventPhotosLookupResult.error) {
+    throw new Error(eventPhotosLookupResult.error.message);
+  }
+
+  if (momentPhotosLookupResult.error) {
+    throw new Error(momentPhotosLookupResult.error.message);
+  }
+
+  const storagePathToEventId = new Map<string, string>();
+  const storagePathToMomentId = new Map<string, string>();
+
+  for (const link of (eventPhotosLookupResult.data ?? []) as EventPhotoLink[]) {
+    if (!link.event_id) continue;
+    const storagePath = resolvePhotoStoragePath(link.photos);
+    if (storagePath) {
+      const normalizedPath = normalizeStoragePath(storagePath);
+      if (normalizedPath) {
+        storagePathToEventId.set(normalizedPath, link.event_id);
+      }
+    }
+  }
+
+  for (const link of (momentPhotosLookupResult.data ??
+    []) as MomentPhotoLink[]) {
+    if (!link.moment_id) continue;
+    const storagePath = resolvePhotoStoragePath(link.photos);
+    if (storagePath) {
+      const normalizedPath = normalizeStoragePath(storagePath);
+      if (normalizedPath) {
+        storagePathToMomentId.set(normalizedPath, link.moment_id);
+      }
+    }
+  }
+
+  const itemsWithResolvedIds = baseItems.map((item) => {
+    const linkedPath = randomPathBySourceId.get(item.sourceId);
+    const rowStoragePath = randomItem(
+      item.imageCandidates.filter(
+        (value) =>
+          !value.startsWith('http://') && !value.startsWith('https://'),
+      ),
+    );
+
+    let resolvedEventId: string | undefined = item.eventId;
+    let resolvedMomentId: string | undefined = item.momentId;
+
+    if (!resolvedEventId && !resolvedMomentId && rowStoragePath) {
+      const normalizedPath = normalizeStoragePath(rowStoragePath);
+      if (normalizedPath) {
+        resolvedEventId = storagePathToEventId.get(normalizedPath);
+        resolvedMomentId = storagePathToMomentId.get(normalizedPath);
+      }
+    }
+
+    return {
+      ...item,
+      linkedPath,
+      rowStoragePath,
+      resolvedEventId,
+      resolvedMomentId,
+    };
+  });
+
+  const eventIdsToFetch = Array.from(
+    new Set(
+      itemsWithResolvedIds
+        .filter((item) => item.resolvedEventId)
+        .map((item) => item.resolvedEventId) as string[],
+    ),
+  );
+
+  const momentIdsToFetch = Array.from(
+    new Set(
+      itemsWithResolvedIds
+        .filter((item) => item.resolvedMomentId)
+        .map((item) => item.resolvedMomentId) as string[],
+    ),
+  );
+
+  const [eventsDataResult, momentsDataResult] = await Promise.all([
+    eventIdsToFetch.length > 0
+      ? supabase
+          .from('events')
+          .select('id, title, notes, occurred_on')
+          .in('id', eventIdsToFetch)
+      : Promise.resolve({ data: [], error: null }),
+    momentIdsToFetch.length > 0
+      ? supabase
+          .from('moments')
+          .select('id, title, description, occurred_on')
+          .in('id', momentIdsToFetch)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  if (eventsDataResult.error) {
+    throw new Error(eventsDataResult.error.message);
+  }
+
+  if (momentsDataResult.error) {
+    throw new Error(momentsDataResult.error.message);
+  }
+
+  const eventsById = new Map(
+    (eventsDataResult.data ?? []).map((row: any) => [row.id, row]),
+  );
+  const momentsById = new Map(
+    (momentsDataResult.data ?? []).map((row: any) => [row.id, row]),
+  );
+
+  return itemsWithResolvedIds
+    .map((item) => {
+      const directUrl = randomItem(
+        item.imageCandidates.filter(
+          (value) =>
+            value.startsWith('http://') || value.startsWith('https://'),
+        ),
+      );
+
+      const imageUrl =
+        directUrl ??
+        (item.linkedPath ? signedUrls.get(item.linkedPath) : undefined) ??
+        (item.rowStoragePath ? signedUrls.get(item.rowStoragePath) : undefined);
+
+      let title = item.title;
+      let description = item.description;
+      let occurredOn = item.occurredOn;
+
+      if (item.resolvedEventId) {
+        const event = eventsById.get(item.resolvedEventId);
+        if (event) {
+          title = event.title;
+          description = event.notes || '';
+          occurredOn = event.occurred_on;
+        }
+      } else if (item.resolvedMomentId) {
+        const moment = momentsById.get(item.resolvedMomentId);
+        if (moment) {
+          title = moment.title;
+          description = moment.description || '';
+          occurredOn = moment.occurred_on;
+        }
+      }
+
+      const type: MemoryWallType =
+        item.typeHint ??
+        (eventPathsById.has(item.sourceId)
+          ? 'event'
+          : momentPathsById.has(item.sourceId)
+            ? 'moment'
+            : item.resolvedEventId
+              ? 'event'
+              : item.resolvedMomentId
+                ? 'moment'
+                : 'moment');
+
+      return {
+        id: item.id,
+        sourceId: item.sourceId,
+        eventId: item.resolvedEventId,
+        momentId: item.resolvedMomentId,
+        title,
+        description,
+        occurredOn,
+        type,
+        imageUrl,
+      } satisfies MemoryWallItem;
+    })
+    .sort((left, right) => right.occurredOn.localeCompare(left.occurredOn));
+}

--- a/services/timelineItems.ts
+++ b/services/timelineItems.ts
@@ -1,0 +1,454 @@
+import { getSignedImageUrlMap, IMAGE_BUCKET_ID } from '@/lib/images';
+import { supabase } from '@/lib/supabase';
+import {
+    getCurrentUserId,
+    type JoinedPhoto,
+    resolvePhotoStoragePath,
+} from '@/services/userContext';
+
+type TimelineItemRow = Record<string, unknown>;
+
+type EventPhotoLink = {
+  event_id?: string | null;
+  photos?: JoinedPhoto;
+};
+
+type MomentPhotoLink = {
+  moment_id?: string | null;
+  photos?: JoinedPhoto;
+};
+
+export type TimelineItem = {
+  id: string;
+  title: string;
+  description: string;
+  occurredOn: string;
+  displayType: string;
+  coverImage?: string;
+  kind?: 'event' | 'moment' | null;
+  sourceId?: string;
+};
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function toIsoDate(value: unknown): string {
+  const asString =
+    toNonEmptyString(value) ??
+    toNonEmptyString((value as { toString?: () => string })?.toString?.()) ??
+    '';
+
+  if (!asString) {
+    return '';
+  }
+
+  const date = new Date(asString);
+  return Number.isNaN(date.getTime()) ? asString : date.toISOString();
+}
+
+function normalizeKind(value: string | null): 'event' | 'moment' | null {
+  if (!value) {
+    return null;
+  }
+
+  const lowered = value.toLowerCase();
+
+  if (lowered.includes('event')) {
+    return 'event';
+  }
+
+  if (lowered.includes('moment')) {
+    return 'moment';
+  }
+
+  return null;
+}
+
+function normalizeTypeLabel(value: string | null): string {
+  if (!value) {
+    return 'Memory';
+  }
+
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+function getImagePathOrUrl(row: TimelineItemRow): string | null {
+  return (
+    toNonEmptyString(row.cover_image_url) ??
+    toNonEmptyString(row.cover_image_path) ??
+    toNonEmptyString(row.cover_image) ??
+    toNonEmptyString(row.photo_storage_path) ??
+    toNonEmptyString(row.primary_photo_storage_path) ??
+    toNonEmptyString(row.image_url) ??
+    toNonEmptyString(row.image) ??
+    toNonEmptyString(row.photo_url) ??
+    toNonEmptyString(row.storage_path)
+  );
+}
+
+function normalizeStoragePath(value: string): string | null {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    try {
+      const url = new URL(trimmed);
+      const path = url.pathname;
+      const prefixes = [
+        `/storage/v1/object/public/${IMAGE_BUCKET_ID}/`,
+        `/storage/v1/object/sign/${IMAGE_BUCKET_ID}/`,
+        `/storage/v1/object/authenticated/${IMAGE_BUCKET_ID}/`,
+      ];
+
+      for (const prefix of prefixes) {
+        if (path.startsWith(prefix)) {
+          return decodeURIComponent(path.slice(prefix.length));
+        }
+      }
+    } catch {
+      return null;
+    }
+
+    return null;
+  }
+
+  const withoutLeadingSlash = trimmed.startsWith('/')
+    ? trimmed.slice(1)
+    : trimmed;
+
+  if (withoutLeadingSlash.startsWith(`${IMAGE_BUCKET_ID}/`)) {
+    return withoutLeadingSlash.slice(IMAGE_BUCKET_ID.length + 1);
+  }
+
+  return withoutLeadingSlash;
+}
+
+function pickSourceId(row: TimelineItemRow): string {
+  return (
+    toNonEmptyString(row.source_item_id) ??
+    toNonEmptyString(row.entity_id) ??
+    toNonEmptyString(row.source_id) ??
+    toNonEmptyString(row.item_id) ??
+    toNonEmptyString(row.event_id) ??
+    toNonEmptyString(row.moment_id) ??
+    toNonEmptyString(row.id) ??
+    ''
+  );
+}
+
+function pickKind(row: TimelineItemRow): 'event' | 'moment' | null {
+  if (toNonEmptyString(row.event_id)) {
+    return 'event';
+  }
+
+  if (toNonEmptyString(row.moment_id)) {
+    return 'moment';
+  }
+
+  return normalizeKind(
+    toNonEmptyString(row.source_table) ??
+      toNonEmptyString(row.table_name) ??
+      toNonEmptyString(row.entity_table) ??
+      toNonEmptyString(row.source_item_type) ??
+      toNonEmptyString(row.entity_type) ??
+      toNonEmptyString(row.item_kind) ??
+      toNonEmptyString(row.item_type) ??
+      toNonEmptyString(row.source_type) ??
+      toNonEmptyString(row.kind) ??
+      toNonEmptyString(row.type),
+  );
+}
+
+function shouldUseKindAsDisplayType(
+  displayType: string,
+  kind: 'event' | 'moment' | null,
+): boolean {
+  if (!kind) {
+    return false;
+  }
+
+  const lowered = displayType.toLowerCase();
+  return lowered === 'memory' || lowered === 'memories';
+}
+
+function resolveCoverImage(
+  imagePathOrUrl: string | null,
+  signedMap: Map<string, string>,
+): string | undefined {
+  if (!imagePathOrUrl) {
+    return undefined;
+  }
+
+  const normalizedPath = normalizeStoragePath(imagePathOrUrl);
+
+  if (!normalizedPath) {
+    return imagePathOrUrl.startsWith('http://') ||
+      imagePathOrUrl.startsWith('https://')
+      ? imagePathOrUrl
+      : undefined;
+  }
+
+  return signedMap.get(normalizedPath);
+}
+
+export async function listTimelineItemsForGroup(
+  groupId: string,
+): Promise<TimelineItem[]> {
+  const userId = await getCurrentUserId();
+
+  if (!userId || !groupId) {
+    return [];
+  }
+
+  const { data, error } = await supabase.from('timeline_items').select('*');
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const rows = ((data ?? []) as TimelineItemRow[]).filter((row) => {
+    const rowGroupId = toNonEmptyString(row.group_id);
+    return !rowGroupId || rowGroupId === groupId;
+  });
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const imagePaths = rows
+    .map((row) => getImagePathOrUrl(row))
+    .filter((value): value is string => Boolean(value))
+    .filter(
+      (value) => !value.startsWith('http://') && !value.startsWith('https://'),
+    );
+
+  const signedMap = await getSignedImageUrlMap(Array.from(new Set(imagePaths)));
+
+  const mappedItems = rows
+    .map((row) => {
+      const title =
+        toNonEmptyString(row.title) ??
+        toNonEmptyString(row.name) ??
+        toNonEmptyString(row.headline) ??
+        'Untitled memory';
+      const description =
+        toNonEmptyString(row.description) ??
+        toNonEmptyString(row.body) ??
+        toNonEmptyString(row.content) ??
+        toNonEmptyString(row.details) ??
+        toNonEmptyString(row.text) ??
+        toNonEmptyString(row.caption) ??
+        toNonEmptyString(row.note) ??
+        toNonEmptyString(row.notes) ??
+        toNonEmptyString(row.message) ??
+        toNonEmptyString(row.subtitle) ??
+        toNonEmptyString(row.summary) ??
+        '';
+      const kind = pickKind(row);
+      const displayType = normalizeTypeLabel(
+        toNonEmptyString(row.display_type) ??
+          toNonEmptyString(row.type_label) ??
+          toNonEmptyString(row.item_label) ??
+          toNonEmptyString(row.source_item_type) ??
+          toNonEmptyString(row.entity_type) ??
+          toNonEmptyString(row.item_kind) ??
+          toNonEmptyString(row.item_type) ??
+          toNonEmptyString(row.source_type) ??
+          toNonEmptyString(row.kind) ??
+          toNonEmptyString(row.category) ??
+          toNonEmptyString(row.mood) ??
+          toNonEmptyString(row.type) ??
+          (kind === 'event' ? 'Event' : kind === 'moment' ? 'Moment' : null),
+      );
+      const imagePathOrUrl = getImagePathOrUrl(row);
+      const sourceId = pickSourceId(row);
+
+      return {
+        id: toNonEmptyString(row.id) ?? sourceId,
+        title,
+        description,
+        occurredOn: toIsoDate(
+          row.occurred_on ?? row.occurred_at ?? row.date ?? row.created_at,
+        ),
+        displayType,
+        coverImage: resolveCoverImage(imagePathOrUrl, signedMap),
+        kind,
+        sourceId,
+      } satisfies TimelineItem;
+    })
+    .filter((item) => Boolean(item.id));
+
+  const candidateSourceIds = Array.from(
+    new Set(
+      mappedItems
+        .map((item) => item.sourceId)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+
+  const [eventsResult, momentsResult] = await Promise.all([
+    candidateSourceIds.length > 0
+      ? supabase
+          .from('events')
+          .select('id, title, notes, mood, occurred_on')
+          .in('id', candidateSourceIds)
+          .eq('group_id', groupId)
+      : Promise.resolve({ data: [], error: null }),
+    candidateSourceIds.length > 0
+      ? supabase
+          .from('moments')
+          .select('id, title, description, category, occurred_on')
+          .in('id', candidateSourceIds)
+          .eq('group_id', groupId)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  if (eventsResult.error) {
+    throw new Error(eventsResult.error.message);
+  }
+
+  if (momentsResult.error) {
+    throw new Error(momentsResult.error.message);
+  }
+
+  const [eventPhotoLinksResult, momentPhotoLinksResult] = await Promise.all([
+    candidateSourceIds.length > 0
+      ? supabase
+          .from('event_photos')
+          .select('event_id, sort_order, photos(storage_path)')
+          .in('event_id', candidateSourceIds)
+          .eq('group_id', groupId)
+          .order('event_id', { ascending: true })
+          .order('sort_order', { ascending: true })
+      : Promise.resolve({ data: [], error: null }),
+    candidateSourceIds.length > 0
+      ? supabase
+          .from('moment_photos')
+          .select('moment_id, sort_order, photos(storage_path)')
+          .in('moment_id', candidateSourceIds)
+          .eq('group_id', groupId)
+          .order('moment_id', { ascending: true })
+          .order('sort_order', { ascending: true })
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  if (eventPhotoLinksResult.error) {
+    throw new Error(eventPhotoLinksResult.error.message);
+  }
+
+  if (momentPhotoLinksResult.error) {
+    throw new Error(momentPhotoLinksResult.error.message);
+  }
+
+  const coverPathBySourceId = new Map<string, string>();
+
+  for (const link of (eventPhotoLinksResult.data ?? []) as EventPhotoLink[]) {
+    const storagePath = resolvePhotoStoragePath(link.photos);
+
+    if (!link.event_id || !storagePath) {
+      continue;
+    }
+
+    if (!coverPathBySourceId.has(link.event_id)) {
+      coverPathBySourceId.set(link.event_id, storagePath);
+    }
+  }
+
+  for (const link of (momentPhotoLinksResult.data ?? []) as MomentPhotoLink[]) {
+    const storagePath = resolvePhotoStoragePath(link.photos);
+
+    if (!link.moment_id || !storagePath) {
+      continue;
+    }
+
+    if (!coverPathBySourceId.has(link.moment_id)) {
+      coverPathBySourceId.set(link.moment_id, storagePath);
+    }
+  }
+
+  const signedCoverUrlsByPath = await getSignedImageUrlMap(
+    Array.from(new Set(Array.from(coverPathBySourceId.values()))),
+  );
+
+  const signedCoverUrlsBySourceId = new Map<string, string>();
+
+  for (const [sourceId, storagePath] of coverPathBySourceId.entries()) {
+    const signedUrl = signedCoverUrlsByPath.get(storagePath);
+
+    if (signedUrl) {
+      signedCoverUrlsBySourceId.set(sourceId, signedUrl);
+    }
+  }
+
+  const eventsById = new Map(
+    (eventsResult.data ?? []).map((event) => [event.id, event]),
+  );
+  const momentsById = new Map(
+    (momentsResult.data ?? []).map((moment) => [moment.id, moment]),
+  );
+
+  return mappedItems
+    .map((item) => {
+      const sourceId = item.sourceId;
+      const matchedEvent = sourceId ? eventsById.get(sourceId) : undefined;
+      const matchedMoment = sourceId ? momentsById.get(sourceId) : undefined;
+
+      if (matchedEvent) {
+        const displayType = shouldUseKindAsDisplayType(
+          item.displayType,
+          'event',
+        )
+          ? 'Event'
+          : item.displayType;
+
+        return {
+          ...item,
+          kind: 'event' as const,
+          title: item.title || matchedEvent.title || 'Untitled event',
+          description: item.description || matchedEvent.notes || '',
+          occurredOn: item.occurredOn || matchedEvent.occurred_on,
+          displayType,
+          coverImage:
+            item.coverImage ??
+            (sourceId ? signedCoverUrlsBySourceId.get(sourceId) : undefined),
+        } satisfies TimelineItem;
+      }
+
+      if (matchedMoment) {
+        const displayType = shouldUseKindAsDisplayType(
+          item.displayType,
+          'moment',
+        )
+          ? 'Moment'
+          : item.displayType;
+
+        return {
+          ...item,
+          kind: 'moment' as const,
+          title: item.title || matchedMoment.title || 'Untitled moment',
+          description: item.description || matchedMoment.description || '',
+          occurredOn: item.occurredOn || matchedMoment.occurred_on,
+          displayType,
+          coverImage:
+            item.coverImage ??
+            (sourceId ? signedCoverUrlsBySourceId.get(sourceId) : undefined),
+        } satisfies TimelineItem;
+      }
+
+      return item;
+    })
+    .sort((left, right) => right.occurredOn.localeCompare(left.occurredOn));
+}


### PR DESCRIPTION
This pull request refactors the Timeline and Memories screens to fetch real data from hooks instead of using hardcoded dummy data. It also improves error and loading state handling, adds support for fallback images, and enhances navigation and UI consistency. Additionally, it updates the `Image` component to handle both URI and local image sources, and improves the modal presentation for memory details.

**Data fetching and state management:**
- Replaces hardcoded memory and timeline data in `index.tsx` and `memories.tsx` with dynamic data fetched via `useTimelineItemsQuery` and `useMemoryWallQuery`, respectively. This includes error and loading state handling, and empty state messaging. [[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR2-R70) [[2]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R44-R129)
- Integrates `useActiveGroup` to scope data queries to the currently active group, ensuring the correct context for data retrieval. [[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR2-R70) [[2]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R44-R129)

**Navigation and linking improvements:**
- Implements dynamic link resolution for timeline and memory items, allowing users to navigate to the correct detail screens based on item type and IDs. [[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR2-R70) [[2]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R44-R129) [[3]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485L189-R255)

**UI and UX enhancements:**
- Adds fallback image support for missing cover images and updates the `Image` component to accept both string URIs and local asset references. [[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR2-R70) [[2]](diffhunk://#diff-d942281ba5ef2ff9470fc7b938d88560bf44371eb81ab2ffad923b4a96fce3e9L9-R9) [[3]](diffhunk://#diff-d942281ba5ef2ff9470fc7b938d88560bf44371eb81ab2ffad923b4a96fce3e9R21-R28) [[4]](diffhunk://#diff-d942281ba5ef2ff9470fc7b938d88560bf44371eb81ab2ffad923b4a96fce3e9R48-R60) [[5]](diffhunk://#diff-d942281ba5ef2ff9470fc7b938d88560bf44371eb81ab2ffad923b4a96fce3e9R72-R73)
- Improves loading, error, and empty state indicators for both screens, providing clear feedback to users. [[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR79-R133) [[2]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R149-R167) [[3]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R317-R343)
- Refines the modal for memory details, displaying additional fields and linking to the appropriate detail page. [[1]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R207-R209) [[2]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485L189-R255)

**Styling and code cleanup:**
- Updates styles to better align with the app's design system, including text colors, spacing, and box shadows. [[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdL147-R146) [[2]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR182-R194) [[3]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485L230-R267) [[4]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485L260-L267) [[5]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R317-R343)
- Removes unused imports and code, and simplifies components by extracting utility functions for formatting and shuffling. [[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR2-R70) [[2]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R44-R129)

**References:**  
[[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR2-R70) [[2]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR79-R133) [[3]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdL147-R146) [[4]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdR182-R194) [[5]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R3-L14) [[6]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485L25-R35) [[7]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R44-R129) [[8]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R149-R167) [[9]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R207-R209) [[10]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485L189-R255) [[11]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485L230-R267) [[12]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485L260-L267) [[13]](diffhunk://#diff-de70d788f654cd1355f9b5fd6801d021af615337d6ea57c595b78c32ee8ed485R317-R343) [[14]](diffhunk://#diff-d942281ba5ef2ff9470fc7b938d88560bf44371eb81ab2ffad923b4a96fce3e9L9-R9) [[15]](diffhunk://#diff-d942281ba5ef2ff9470fc7b938d88560bf44371eb81ab2ffad923b4a96fce3e9R21-R28) [[16]](diffhunk://#diff-d942281ba5ef2ff9470fc7b938d88560bf44371eb81ab2ffad923b4a96fce3e9R48-R60) [[17]](diffhunk://#diff-d942281ba5ef2ff9470fc7b938d88560bf44371eb81ab2ffad923b4a96fce3e9R72-R73)