### PR TITLE
Polish event and moment interactions and simplify the shared flow

### DIFF
--- a/app/(tabs)/events/index.tsx
+++ b/app/(tabs)/events/index.tsx
@@ -2,11 +2,13 @@ import { Card } from '@/components/ui/Card';
 import { Text } from '@/components/ui/Text';
 import { useActiveGroup } from '@/hooks/useActiveGroup';
 import { useEventsQuery } from '@/hooks/useEvents';
+import { triggerTapFeedback } from '@/lib/interaction';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
 import { text } from '@/theme/type';
-import { type Href, Link } from 'expo-router';
+import { type Href, router } from 'expo-router';
 import { Plus } from 'lucide-react-native';
+import { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -51,6 +53,32 @@ export default function EventsIndexScreen() {
     activeGroup?.groupKind === 'personal'
       ? 'Personal'
       : (activeGroup?.name ?? 'this space');
+  const [isNavigating, setIsNavigating] = useState(false);
+  const isNavigatingRef = useRef(false);
+  const releaseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (releaseTimeoutRef.current) {
+        clearTimeout(releaseTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  function handleNavigate(href: Href) {
+    if (isNavigatingRef.current) {
+      return;
+    }
+
+    isNavigatingRef.current = true;
+    setIsNavigating(true);
+    void triggerTapFeedback();
+    router.push(href);
+    releaseTimeoutRef.current = setTimeout(() => {
+      isNavigatingRef.current = false;
+      setIsNavigating(false);
+    }, 700);
+  }
 
   return (
     <View style={styles.container}>
@@ -79,19 +107,19 @@ export default function EventsIndexScreen() {
 
           {!isLoadingGroups && !eventsQuery.isPending && !loadError
             ? events.map((event) => (
-                <Link
-                  asChild
-                  href={`/events/${event.id}` as Href}
+                <Pressable
+                  accessibilityHint="Opens this event"
+                  accessibilityRole="button"
+                  disabled={isNavigating}
                   key={event.id}
+                  onPress={() => handleNavigate(`/events/${event.id}`)}
+                  style={({ pressed }) => [
+                    styles.cardPressable,
+                    pressed ? styles.cardPressed : null,
+                    isNavigating ? styles.cardDisabled : null,
+                  ]}
                 >
-                  <Pressable
-                    accessibilityHint="Opens this event"
-                    accessibilityRole="button"
-                    style={({ pressed }) => [
-                      styles.cardPressable,
-                      pressed ? styles.cardPressed : null,
-                    ]}
-                  >
+                  <View pointerEvents="none" style={styles.cardInner}>
                     <Card
                       color={sectionColors.events}
                       coverImage={event.coverImage ?? FALLBACK_COVER_IMAGE}
@@ -101,17 +129,24 @@ export default function EventsIndexScreen() {
                       type={event.mood ?? 'No mood set'}
                       variant="compressed"
                     />
-                  </Pressable>
-                </Link>
+                  </View>
+                </Pressable>
               ))
             : null}
         </View>
       </ScrollView>
-      <Link href="/events/new" asChild>
-        <Pressable accessibilityRole="button" style={styles.createButton}>
-          <Plus color={baseColors.bg} size={28} strokeWidth={2.4} />
-        </Pressable>
-      </Link>
+      <Pressable
+        accessibilityRole="button"
+        disabled={isNavigating}
+        onPress={() => handleNavigate('/events/new')}
+        style={({ pressed }) => [
+          styles.createButton,
+          pressed ? styles.cardPressed : null,
+          isNavigating ? styles.createButtonDisabled : null,
+        ]}
+      >
+        <Plus color={baseColors.bg} size={28} strokeWidth={2.4} />
+      </Pressable>
     </View>
   );
 }
@@ -132,8 +167,14 @@ const styles = StyleSheet.create({
   cardPressable: {
     borderRadius: 26,
   },
+  cardInner: {
+    borderRadius: 26,
+  },
   cardPressed: {
-    opacity: 0.92,
+    opacity: 0.82,
+  },
+  cardDisabled: {
+    opacity: 0.55,
   },
   emptyText: {
     color: baseColors.textSoft,
@@ -166,5 +207,8 @@ const styles = StyleSheet.create({
     shadowOpacity: 1,
     shadowRadius: 18,
     elevation: 4,
+  },
+  createButtonDisabled: {
+    opacity: 0.55,
   },
 });

--- a/app/(tabs)/moments/index.tsx
+++ b/app/(tabs)/moments/index.tsx
@@ -2,11 +2,13 @@ import { Card } from '@/components/ui/Card';
 import { Text } from '@/components/ui/Text';
 import { useActiveGroup } from '@/hooks/useActiveGroup';
 import { useMomentsQuery } from '@/hooks/useMoments';
+import { triggerTapFeedback } from '@/lib/interaction';
 import { baseColors, sectionColors } from '@/theme/colors';
 import { space } from '@/theme/space';
 import { text } from '@/theme/type';
-import { type Href, Link } from 'expo-router';
+import { type Href, router } from 'expo-router';
 import { Plus } from 'lucide-react-native';
+import { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -62,6 +64,32 @@ export default function MomentsScreen() {
     activeGroup?.groupKind === 'personal'
       ? 'Personal'
       : (activeGroup?.name ?? 'this space');
+  const [isNavigating, setIsNavigating] = useState(false);
+  const isNavigatingRef = useRef(false);
+  const releaseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (releaseTimeoutRef.current) {
+        clearTimeout(releaseTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  function handleNavigate(href: Href) {
+    if (isNavigatingRef.current) {
+      return;
+    }
+
+    isNavigatingRef.current = true;
+    setIsNavigating(true);
+    void triggerTapFeedback();
+    router.push(href);
+    releaseTimeoutRef.current = setTimeout(() => {
+      isNavigatingRef.current = false;
+      setIsNavigating(false);
+    }, 700);
+  }
 
   return (
     <View style={styles.container}>
@@ -90,19 +118,19 @@ export default function MomentsScreen() {
 
           {!isLoadingGroups && !momentsQuery.isPending && !loadError
             ? moments.map((moment) => (
-                <Link
-                  asChild
-                  href={`/moments/${moment.id}` as Href}
+                <Pressable
+                  accessibilityHint="Opens this moment"
+                  accessibilityRole="button"
+                  disabled={isNavigating}
                   key={moment.id}
+                  onPress={() => handleNavigate(`/moments/${moment.id}`)}
+                  style={({ pressed }) => [
+                    styles.cardPressable,
+                    pressed ? styles.cardPressed : null,
+                    isNavigating ? styles.cardDisabled : null,
+                  ]}
                 >
-                  <Pressable
-                    accessibilityHint="Opens this moment"
-                    accessibilityRole="button"
-                    style={({ pressed }) => [
-                      styles.cardPressable,
-                      pressed ? styles.cardPressed : null,
-                    ]}
-                  >
+                  <View pointerEvents="none" style={styles.cardInner}>
                     <Card
                       color={sectionColors.moments}
                       coverImage={moment.coverImage ?? FALLBACK_COVER_IMAGE}
@@ -112,17 +140,24 @@ export default function MomentsScreen() {
                       type={formatMomentType(moment.category)}
                       variant="default"
                     />
-                  </Pressable>
-                </Link>
+                  </View>
+                </Pressable>
               ))
             : null}
         </View>
       </ScrollView>
-      <Link href="/moments/new" asChild>
-        <Pressable accessibilityRole="button" style={styles.createButton}>
-          <Plus color={baseColors.bg} size={28} strokeWidth={2.4} />
-        </Pressable>
-      </Link>
+      <Pressable
+        accessibilityRole="button"
+        disabled={isNavigating}
+        onPress={() => handleNavigate('/moments/new')}
+        style={({ pressed }) => [
+          styles.createButton,
+          pressed ? styles.cardPressed : null,
+          isNavigating ? styles.createButtonDisabled : null,
+        ]}
+      >
+        <Plus color={baseColors.bg} size={28} strokeWidth={2.4} />
+      </Pressable>
     </View>
   );
 }
@@ -143,8 +178,14 @@ const styles = StyleSheet.create({
   cardPressable: {
     borderRadius: 26,
   },
+  cardInner: {
+    borderRadius: 26,
+  },
   cardPressed: {
-    opacity: 0.92,
+    opacity: 0.82,
+  },
+  cardDisabled: {
+    opacity: 0.55,
   },
   emptyText: {
     color: baseColors.textSoft,
@@ -177,5 +218,8 @@ const styles = StyleSheet.create({
     shadowOpacity: 1,
     shadowRadius: 18,
     elevation: 4,
+  },
+  createButtonDisabled: {
+    opacity: 0.55,
   },
 });

--- a/app/events/[id].tsx
+++ b/app/events/[id].tsx
@@ -7,6 +7,12 @@ import PopoverMenu from '@/components/ui/PopoverMenu';
 import { Text } from '@/components/ui/Text';
 import { useActiveGroup } from '@/hooks/useActiveGroup';
 import {
+  triggerDestructiveFeedback,
+  triggerErrorFeedback,
+  triggerSuccessFeedback,
+  triggerTapFeedback,
+} from '@/lib/interaction';
+import {
   useDeleteEventMutation,
   useEventDetailQuery,
   useUpdateEventMutation,
@@ -167,6 +173,11 @@ export default function EventDetailScreen() {
   const retryUploadsDisabled =
     isDeleting || isSavingPhotos || hasPendingUploads;
   const retrySaveDisabled = isMutatingEvent || hasPendingUploads;
+  const deleteActionLabel = isDeleting
+    ? 'Deleting...'
+    : isSavingPhotos
+      ? 'Saving photos...'
+      : 'Delete event';
 
   useEffect(() => {
     if (!event) {
@@ -216,14 +227,14 @@ export default function EventDetailScreen() {
   const savePhotos = useCallback(
     async (nextPhotos: SelectedImage[]) => {
       if (!eventId || !activeGroup?.id || !event) {
-        return;
+        return false;
       }
 
       const uploadedPhotos = getUploadedPhotos(nextPhotos);
       const nextPhotoKey = getPhotoKey(uploadedPhotos);
 
       if (nextPhotoKey === eventPhotoKey) {
-        return;
+        return true;
       }
 
       lastSubmittedPhotoKeyRef.current = nextPhotoKey;
@@ -237,10 +248,12 @@ export default function EventDetailScreen() {
           ...getEventPhotoValues(event),
           photos: uploadedPhotos,
         });
+        return true;
       } catch (error) {
         failedSavePhotoKeyRef.current = nextPhotoKey;
         lastSubmittedPhotoKeyRef.current = null;
         setSaveError(getErrorMessage(error));
+        return false;
       }
     },
     [activeGroup?.id, event, eventId, eventPhotoKey, updateEventMutation],
@@ -285,18 +298,56 @@ export default function EventDetailScreen() {
     setPhotos(nextPhotos);
   }
 
+  async function handleRetryFailedUploads() {
+    if (retryUploadsDisabled) {
+      return;
+    }
+
+    setSaveError(null);
+    const result = await startUpload(failedUploads);
+
+    if (result.failedIds.length === 0) {
+      void triggerSuccessFeedback();
+      return;
+    }
+
+    setSaveError(
+      'Some photos still failed to upload. Retry them again or remove them.',
+    );
+    void triggerErrorFeedback();
+  }
+
+  async function handleRetrySave() {
+    if (retrySaveDisabled) {
+      return;
+    }
+
+    failedSavePhotoKeyRef.current = null;
+    const didSave = await savePhotos(photos);
+
+    if (didSave) {
+      void triggerSuccessFeedback();
+      return;
+    }
+
+    void triggerErrorFeedback();
+  }
+
   const removeEvent = async () => {
     if (!eventId || !activeGroup?.id) {
       return;
     }
 
     try {
+      await triggerDestructiveFeedback();
       await deleteEventMutation.mutateAsync({
         eventId,
         groupId: activeGroup.id,
       });
+      void triggerSuccessFeedback();
       router.back();
     } catch (error) {
+      void triggerErrorFeedback();
       Alert.alert(
         'Could not delete event',
         error instanceof Error ? error.message : 'Please try again.',
@@ -311,6 +362,7 @@ export default function EventDetailScreen() {
       return;
     }
 
+    void triggerTapFeedback();
     router.push(`/events/new?eventId=${encodeURIComponent(eventId)}`);
   };
 
@@ -437,10 +489,7 @@ export default function EventDetailScreen() {
                 accessibilityLabel="Retry failed uploads"
                 accessibilityRole="button"
                 disabled={retryUploadsDisabled}
-                onPress={() => {
-                  setSaveError(null);
-                  void startUpload(failedUploads);
-                }}
+                onPress={handleRetryFailedUploads}
                 style={({ pressed }) => [
                   styles.retryButton,
                   pressed ? styles.retryButtonPressed : null,
@@ -459,10 +508,7 @@ export default function EventDetailScreen() {
                   accessibilityLabel="Retry saving photos"
                   accessibilityRole="button"
                   disabled={retrySaveDisabled}
-                  onPress={() => {
-                    failedSavePhotoKeyRef.current = null;
-                    void savePhotos(photos);
-                  }}
+                  onPress={handleRetrySave}
                   style={({ pressed }) => [
                     styles.retryButton,
                     pressed ? styles.retryButtonPressed : null,
@@ -502,7 +548,10 @@ export default function EventDetailScreen() {
           accessibilityLabel="More options"
           accessibilityRole="button"
           disabled={isMutatingEvent}
-          onPress={() => setIsMenuOpen(true)}
+          onPress={() => {
+            void triggerTapFeedback();
+            setIsMenuOpen(true);
+          }}
           style={[
             styles.menuButton,
             isMutatingEvent ? styles.menuButtonDisabled : null,
@@ -519,11 +568,7 @@ export default function EventDetailScreen() {
             onPress: handleEdit,
           },
           {
-            label: isDeleting
-              ? 'Deleting...'
-              : isSavingPhotos
-                ? 'Saving photos...'
-                : 'Delete event',
+            label: deleteActionLabel,
             onPress: handleDelete,
             disabled: isMutatingEvent,
             variant: 'danger',

--- a/app/moments/[id].tsx
+++ b/app/moments/[id].tsx
@@ -7,6 +7,12 @@ import PopoverMenu from '@/components/ui/PopoverMenu';
 import { Text } from '@/components/ui/Text';
 import { useActiveGroup } from '@/hooks/useActiveGroup';
 import {
+  triggerDestructiveFeedback,
+  triggerErrorFeedback,
+  triggerSuccessFeedback,
+  triggerTapFeedback,
+} from '@/lib/interaction';
+import {
   useDeleteMomentMutation,
   useMomentDetailQuery,
   useUpdateMomentMutation,
@@ -226,14 +232,14 @@ export default function MomentDetailScreen() {
   const savePhotos = useCallback(
     async (nextPhotos: SelectedImage[]) => {
       if (!momentId || !activeGroup?.id || !moment) {
-        return;
+        return false;
       }
 
       const uploadedPhotos = getUploadedPhotos(nextPhotos);
       const nextPhotoKey = getPhotoKey(uploadedPhotos);
 
       if (nextPhotoKey === momentPhotoKey) {
-        return;
+        return true;
       }
 
       lastSubmittedPhotoKeyRef.current = nextPhotoKey;
@@ -247,10 +253,12 @@ export default function MomentDetailScreen() {
           ...getMomentPhotoValues(moment),
           photos: uploadedPhotos,
         });
+        return true;
       } catch (error) {
         failedSavePhotoKeyRef.current = nextPhotoKey;
         lastSubmittedPhotoKeyRef.current = null;
         setSaveError(getErrorMessage(error));
+        return false;
       }
     },
     [activeGroup?.id, moment, momentId, momentPhotoKey, updateMomentMutation],
@@ -295,14 +303,39 @@ export default function MomentDetailScreen() {
     setPhotos(nextPhotos);
   }
 
-  function handleRetryFailedUploads() {
+  async function handleRetryFailedUploads() {
+    if (retryUploadsDisabled) {
+      return;
+    }
+
     setSaveError(null);
-    void startUpload(failedUploads);
+    const result = await startUpload(failedUploads);
+
+    if (result.failedIds.length === 0) {
+      void triggerSuccessFeedback();
+      return;
+    }
+
+    setSaveError(
+      'Some photos still failed to upload. Retry them again or remove them.',
+    );
+    void triggerErrorFeedback();
   }
 
-  function handleRetrySave() {
+  async function handleRetrySave() {
+    if (retrySaveDisabled) {
+      return;
+    }
+
     failedSavePhotoKeyRef.current = null;
-    void savePhotos(photos);
+    const didSave = await savePhotos(photos);
+
+    if (didSave) {
+      void triggerSuccessFeedback();
+      return;
+    }
+
+    void triggerErrorFeedback();
   }
 
   const removeMoment = async () => {
@@ -311,12 +344,15 @@ export default function MomentDetailScreen() {
     }
 
     try {
+      await triggerDestructiveFeedback();
       await deleteMomentMutation.mutateAsync({
         momentId,
         groupId: activeGroup.id,
       });
+      void triggerSuccessFeedback();
       router.back();
     } catch (error) {
+      void triggerErrorFeedback();
       Alert.alert(
         'Could not delete moment',
         error instanceof Error ? error.message : 'Please try again.',
@@ -331,6 +367,7 @@ export default function MomentDetailScreen() {
       return;
     }
 
+    void triggerTapFeedback();
     router.push(`/moments/new?momentId=${encodeURIComponent(momentId)}`);
   };
 
@@ -425,6 +462,7 @@ export default function MomentDetailScreen() {
               maxImages={MAX_IMAGES_PER_UPLOAD}
               onChange={handlePhotoChange}
               onRequestUpload={startUpload}
+              showRemoveButton={false}
               value={photos}
             />
 
@@ -493,7 +531,10 @@ export default function MomentDetailScreen() {
           accessibilityLabel="More options"
           accessibilityRole="button"
           disabled={isMutatingMoment}
-          onPress={() => setIsMenuOpen(true)}
+          onPress={() => {
+            void triggerTapFeedback();
+            setIsMenuOpen(true);
+          }}
           style={[
             styles.menuButton,
             isMutatingMoment ? styles.menuButtonDisabled : null,

--- a/components/EventForm.tsx
+++ b/components/EventForm.tsx
@@ -8,11 +8,12 @@ import Chip from '@/components/ui/Chip';
 import Divider from '@/components/ui/Divider';
 import { Field, Input } from '@/components/ui/Input';
 import { Text } from '@/components/ui/Text';
+import { useEntryForm } from '@/hooks/useEntryForm';
 import {
   useCreateEventMutation,
   useUpdateEventMutation,
 } from '@/hooks/useEvents';
-import { useImageUpload } from '@/hooks/useImageUpload';
+import { triggerSelectionFeedback } from '@/lib/interaction';
 import { MAX_IMAGES_PER_UPLOAD } from '@/lib/images';
 import {
   createEventSchema,
@@ -23,7 +24,7 @@ import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
 import { useForm } from '@tanstack/react-form';
 import { router } from 'expo-router';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -35,7 +36,6 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-const SAVE_TIMEOUT_MS = 10000;
 const MOOD_OPTIONS = [
   'Magical',
   'Romantic',
@@ -53,47 +53,6 @@ export type EventFormProps = {
   isEdit: boolean;
 };
 
-function getUploadedPhotos(photos: SelectedImage[]) {
-  return photos
-    .filter(
-      (photo) =>
-        photo.uploadStatus === 'uploaded' && Boolean(photo.storagePath),
-    )
-    .slice(0, MAX_IMAGES_PER_UPLOAD)
-    .map((photo) => ({ storagePath: photo.storagePath! }));
-}
-
-function getFailedUploadMessage(uploadError: string | null) {
-  return uploadError
-    ? `Some photos failed to upload: ${uploadError}`
-    : 'Some photos failed to upload. Remove or retry them before saving.';
-}
-
-function getErrorMessage(error: unknown) {
-  return error instanceof Error
-    ? error.message
-    : 'Failed to save event. Please try again.';
-}
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      reject(new Error('Failed to save event. Please try again.'));
-    }, timeoutMs);
-
-    promise.then(
-      (value) => {
-        clearTimeout(timeoutId);
-        resolve(value);
-      },
-      (error) => {
-        clearTimeout(timeoutId);
-        reject(error);
-      },
-    );
-  });
-}
-
 export default function EventForm({
   activeGroupId,
   eventId,
@@ -101,47 +60,8 @@ export default function EventForm({
   initialValues,
   isEdit,
 }: EventFormProps) {
-  const [photos, setPhotos] = useState(initialPhotos);
-  const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
   const createEventMutation = useCreateEventMutation();
   const updateEventMutation = useUpdateEventMutation();
-  const { startUpload } = useImageUpload({
-    bucket: 'events',
-    setImages: setPhotos,
-  });
-  const isUploading = photos.some(
-    (photo) => photo.uploadStatus === 'uploading',
-  );
-  const failedUploads = photos.filter(
-    (photo) => photo.uploadStatus === 'failed',
-  );
-  const hasFailedUploads = failedUploads.length > 0;
-  const firstFailedUploadError =
-    failedUploads.find((photo) => Boolean(photo.uploadError))?.uploadError ??
-    null;
-  const uploadedPhotos = getUploadedPhotos(photos);
-  const retryUploadsDisabled = isUploading || isSaving;
-
-  const saveEvent = async (values: CreateEventValues, groupId: string) => {
-    if (isEdit && eventId) {
-      await updateEventMutation.mutateAsync({
-        ...values,
-        eventId,
-        groupId,
-        photos: uploadedPhotos,
-      });
-      return;
-    }
-
-    await createEventMutation.mutateAsync({
-      ...values,
-      groupId,
-      photos: uploadedPhotos,
-    });
-  };
-
   const form = useForm({
     defaultValues: initialValues,
     onSubmit: async ({ value }) => {
@@ -155,18 +75,41 @@ export default function EventForm({
         throw new Error('Choose a space before saving this event.');
       }
 
-      try {
-        await saveEvent(parsed.data, activeGroupId);
-      } catch (error) {
-        if (error instanceof Error) {
-          throw error;
-        }
-
-        throw new Error('Failed to save event. Please try again.');
+      if (isEdit && eventId) {
+        await updateEventMutation.mutateAsync({
+          ...parsed.data,
+          eventId,
+          groupId: activeGroupId,
+          photos: uploadedPhotos,
+        });
+        return;
       }
 
-      router.back();
+      await createEventMutation.mutateAsync({
+        ...parsed.data,
+        groupId: activeGroupId,
+        photos: uploadedPhotos,
+      });
     },
+  });
+  const {
+    failedUploads,
+    handleRetryFailedUploads,
+    handleSave,
+    hasTriedSubmit,
+    photos,
+    retryUploadsDisabled,
+    saveDisabled,
+    saveState,
+    setPhotos,
+    startUpload,
+    submitError,
+    uploadedPhotos,
+  } = useEntryForm({
+    bucket: 'events',
+    initialPhotos,
+    onSaved: () => router.back(),
+    saveErrorMessage: 'Failed to save event. Please try again.',
   });
 
   const validation = useMemo(
@@ -176,43 +119,6 @@ export default function EventForm({
   const fieldErrors = validation.success
     ? {}
     : validation.error.flatten().fieldErrors;
-  const submitError = saveError ?? form.state.errorMap.onSubmit;
-
-  const handleSave = async () => {
-    if (isSaving) {
-      return;
-    }
-
-    setHasTriedSubmit(true);
-    setSaveError(null);
-    if (!validation.success) {
-      return;
-    }
-
-    if (isUploading) {
-      setSaveError('Please wait for photos to finish uploading.');
-      return;
-    }
-
-    if (hasFailedUploads) {
-      setSaveError(getFailedUploadMessage(firstFailedUploadError));
-      return;
-    }
-
-    if (!activeGroupId) {
-      setSaveError('Choose a space before saving this event.');
-      return;
-    }
-
-    setIsSaving(true);
-
-    try {
-      await withTimeout(form.handleSubmit(), SAVE_TIMEOUT_MS);
-    } catch (error) {
-      setSaveError(getErrorMessage(error));
-      setIsSaving(false);
-    }
-  };
 
   return (
     <SafeAreaView style={styles.screen} edges={['top']}>
@@ -223,7 +129,9 @@ export default function EventForm({
         <ModalTopBar
           color={sectionColors.events}
           onClose={() => router.back()}
-          onSave={handleSave}
+          onSave={() => void handleSave(validation.success, form.handleSubmit)}
+          saveDisabled={saveDisabled}
+          saveState={saveState}
           title={isEdit ? 'Edit Event' : 'New Event'}
         />
         <Divider color={sectionColors.events} />
@@ -294,7 +202,14 @@ export default function EventForm({
                         color={sectionColors.events}
                         isSelected={field.state.value === option}
                         label={option}
-                        setIsSelected={() => field.handleChange(option)}
+                        setIsSelected={() => {
+                          if (field.state.value === option) {
+                            return;
+                          }
+
+                          void triggerSelectionFeedback();
+                          field.handleChange(option);
+                        }}
                         style={styles.moodChip}
                       />
                     ))}
@@ -331,16 +246,13 @@ export default function EventForm({
               value={photos}
             />
 
-            {hasFailedUploads ? (
+            {failedUploads.length > 0 ? (
               <Pressable
                 accessibilityHint="Retries failed photo uploads"
                 accessibilityLabel="Retry failed uploads"
                 accessibilityRole="button"
                 disabled={retryUploadsDisabled}
-                onPress={() => {
-                  setSaveError(null);
-                  void startUpload(failedUploads);
-                }}
+                onPress={handleRetryFailedUploads}
                 style={({ pressed }) => [
                   styles.retryButton,
                   pressed ? styles.retryButtonPressed : null,
@@ -355,7 +267,7 @@ export default function EventForm({
               <Text style={styles.errorText}>{submitError}</Text>
             ) : null}
 
-            {isSaving ? (
+            {saveState === 'saving' ? (
               <View style={styles.submittingRow}>
                 <ActivityIndicator color={sectionColors.events} />
                 <Text style={styles.submittingText}>Saving event...</Text>

--- a/components/ModalTopBar.tsx
+++ b/components/ModalTopBar.tsx
@@ -1,4 +1,5 @@
 import { Text } from '@/components/ui/Text';
+import { type SaveState } from '@/lib/interaction';
 import { baseColors } from '@/theme/colors';
 import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
@@ -12,9 +13,20 @@ interface HeaderProps {
   color?: string;
   onClose?: () => void;
   onSave?: () => void;
+  saveDisabled?: boolean;
+  saveState?: SaveState;
 }
 
-export default function Header({ title, color, onClose, onSave }: HeaderProps) {
+export default function Header({
+  title,
+  color,
+  onClose,
+  onSave,
+  saveDisabled = false,
+  saveState = 'idle',
+}: HeaderProps) {
+  const hasSaveAction = typeof onSave === 'function';
+
   return (
     <SafeAreaView edges={['top']} style={styles.safeArea}>
       <View style={[styles.topBarContainer]}>
@@ -32,13 +44,17 @@ export default function Header({ title, color, onClose, onSave }: HeaderProps) {
           {title}
         </Text>
         <View style={[styles.spaceDiv, { alignItems: 'flex-end' }]}>
-          <Button
-            alignSelf="flex-end"
-            color={color}
-            label="Save"
-            onPress={onSave}
-            variant="default"
-          />
+          {hasSaveAction ? (
+            <Button
+              alignSelf="flex-end"
+              color={color}
+              disabled={saveDisabled}
+              label="Save"
+              onPress={onSave}
+              saveState={saveState}
+              variant="default"
+            />
+          ) : null}
         </View>
       </View>
     </SafeAreaView>

--- a/components/MomentForm.tsx
+++ b/components/MomentForm.tsx
@@ -8,11 +8,14 @@ import Divider from '@/components/ui/Divider';
 import { Dropdown } from '@/components/ui/Dropdown';
 import { Input } from '@/components/ui/Input';
 import { Text } from '@/components/ui/Text';
+import { useEntryForm } from '@/hooks/useEntryForm';
 import {
+  type CreateMomentMutationInput,
   useCreateMomentMutation,
+  type UpdateMomentMutationInput,
   useUpdateMomentMutation,
 } from '@/hooks/useMoments';
-import { useImageUpload } from '@/hooks/useImageUpload';
+import { triggerSelectionFeedback } from '@/lib/interaction';
 import { MAX_IMAGES_PER_UPLOAD } from '@/lib/images';
 import {
   createMomentSchema,
@@ -23,7 +26,7 @@ import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
 import { useForm } from '@tanstack/react-form';
 import { router } from 'expo-router';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -35,7 +38,6 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-const SAVE_TIMEOUT_MS = 10000;
 const MOMENT_TYPE_OPTIONS = [
   { label: 'Food', value: 'food' },
   { label: 'Outfit', value: 'outfit' },
@@ -54,45 +56,25 @@ export type MomentFormProps = {
   isEdit: boolean;
 };
 
-function getUploadedPhotos(photos: SelectedImage[]) {
-  return photos
+function getOptimisticMomentData(
+  photos: SelectedImage[],
+): NonNullable<CreateMomentMutationInput['optimistic']> {
+  const optimisticPhotos = photos
     .filter(
       (photo) =>
-        photo.uploadStatus === 'uploaded' && Boolean(photo.storagePath),
+        photo.uploadStatus === 'uploaded' &&
+        Boolean(photo.storagePath) &&
+        Boolean(photo.uri),
     )
-    .slice(0, MAX_IMAGES_PER_UPLOAD)
-    .map((photo) => ({ storagePath: photo.storagePath! }));
-}
+    .map((photo) => ({
+      storagePath: photo.storagePath!,
+      url: photo.uri,
+    }));
 
-function getFailedUploadMessage(uploadError: string | null) {
-  return uploadError
-    ? `Some photos failed to upload: ${uploadError}`
-    : 'Some photos failed to upload. Remove or retry them before saving.';
-}
-
-function getErrorMessage(error: unknown) {
-  return error instanceof Error
-    ? error.message
-    : 'Failed to save moment. Please try again.';
-}
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      reject(new Error('Failed to save moment. Please try again.'));
-    }, timeoutMs);
-
-    promise.then(
-      (value) => {
-        clearTimeout(timeoutId);
-        resolve(value);
-      },
-      (error) => {
-        clearTimeout(timeoutId);
-        reject(error);
-      },
-    );
-  });
+  return {
+    coverImage: optimisticPhotos[0]?.url,
+    photos: optimisticPhotos,
+  };
 }
 
 export default function MomentForm({
@@ -102,47 +84,8 @@ export default function MomentForm({
   initialValues,
   isEdit,
 }: MomentFormProps) {
-  const [photos, setPhotos] = useState(initialPhotos);
-  const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
   const createMomentMutation = useCreateMomentMutation();
   const updateMomentMutation = useUpdateMomentMutation();
-  const { startUpload } = useImageUpload({
-    bucket: 'moments',
-    setImages: setPhotos,
-  });
-  const isUploading = photos.some(
-    (photo) => photo.uploadStatus === 'uploading',
-  );
-  const failedUploads = photos.filter(
-    (photo) => photo.uploadStatus === 'failed',
-  );
-  const hasFailedUploads = failedUploads.length > 0;
-  const firstFailedUploadError =
-    failedUploads.find((photo) => Boolean(photo.uploadError))?.uploadError ??
-    null;
-  const uploadedPhotos = getUploadedPhotos(photos);
-  const retryUploadsDisabled = isUploading || isSaving;
-
-  const saveMoment = async (values: CreateMomentValues, groupId: string) => {
-    if (isEdit && momentId) {
-      await updateMomentMutation.mutateAsync({
-        momentId,
-        ...values,
-        groupId,
-        photos: uploadedPhotos,
-      });
-      return;
-    }
-
-    await createMomentMutation.mutateAsync({
-      ...values,
-      groupId,
-      photos: uploadedPhotos,
-    });
-  };
-
   const form = useForm({
     defaultValues: initialValues,
     onSubmit: async ({ value }) => {
@@ -156,18 +99,45 @@ export default function MomentForm({
         throw new Error('Choose a space before saving this moment.');
       }
 
-      try {
-        await saveMoment(parsed.data, activeGroupId);
-      } catch (error) {
-        if (error instanceof Error) {
-          throw error;
-        }
+      const optimistic = getOptimisticMomentData(photos);
 
-        throw new Error('Failed to save moment. Please try again.');
+      if (isEdit && momentId) {
+        await updateMomentMutation.mutateAsync({
+          momentId,
+          ...parsed.data,
+          groupId: activeGroupId,
+          optimistic,
+          photos: uploadedPhotos,
+        } satisfies UpdateMomentMutationInput);
+        return;
       }
 
-      router.back();
+      await createMomentMutation.mutateAsync({
+        ...parsed.data,
+        groupId: activeGroupId,
+        optimistic,
+        photos: uploadedPhotos,
+      } satisfies CreateMomentMutationInput);
     },
+  });
+  const {
+    failedUploads,
+    handleRetryFailedUploads,
+    handleSave,
+    hasTriedSubmit,
+    photos,
+    retryUploadsDisabled,
+    saveDisabled,
+    saveState,
+    setPhotos,
+    startUpload,
+    submitError,
+    uploadedPhotos,
+  } = useEntryForm({
+    bucket: 'moments',
+    initialPhotos,
+    onSaved: () => router.back(),
+    saveErrorMessage: 'Failed to save moment. Please try again.',
   });
 
   const validation = useMemo(
@@ -177,48 +147,6 @@ export default function MomentForm({
   const fieldErrors = validation.success
     ? {}
     : validation.error.flatten().fieldErrors;
-  const submitError = saveError ?? form.state.errorMap.onSubmit;
-
-  const handleSave = async () => {
-    if (isSaving) {
-      return;
-    }
-
-    setHasTriedSubmit(true);
-    setSaveError(null);
-    if (!validation.success) {
-      return;
-    }
-
-    if (isUploading) {
-      setSaveError('Please wait for photos to finish uploading.');
-      return;
-    }
-
-    if (hasFailedUploads) {
-      setSaveError(getFailedUploadMessage(firstFailedUploadError));
-      return;
-    }
-
-    if (!activeGroupId) {
-      setSaveError('Choose a space before saving this moment.');
-      return;
-    }
-
-    setIsSaving(true);
-
-    try {
-      await withTimeout(form.handleSubmit(), SAVE_TIMEOUT_MS);
-    } catch (error) {
-      setSaveError(getErrorMessage(error));
-      setIsSaving(false);
-    }
-  };
-
-  function handleRetryFailedUploads() {
-    setSaveError(null);
-    void startUpload(failedUploads);
-  }
 
   return (
     <SafeAreaView style={styles.screen} edges={['top']}>
@@ -229,7 +157,9 @@ export default function MomentForm({
         <ModalTopBar
           color={sectionColors.moments}
           onClose={() => router.back()}
-          onSave={handleSave}
+          onSave={() => void handleSave(validation.success, form.handleSubmit)}
+          saveDisabled={saveDisabled}
+          saveState={saveState}
           title={isEdit ? 'Edit Moment' : 'New Moment'}
         />
         <Divider color={sectionColors.moments} />
@@ -247,7 +177,14 @@ export default function MomentForm({
               {(field) => (
                 <Dropdown
                   color={sectionColors.moments}
-                  onChange={field.handleChange}
+                  onChange={(value) => {
+                    if (field.state.value === value) {
+                      return;
+                    }
+
+                    void triggerSelectionFeedback();
+                    field.handleChange(value);
+                  }}
                   options={MOMENT_TYPE_OPTIONS}
                   placeholder="Moment type"
                   value={field.state.value || undefined}
@@ -315,7 +252,7 @@ export default function MomentForm({
               value={photos}
             />
 
-            {hasFailedUploads ? (
+            {failedUploads.length > 0 ? (
               <Pressable
                 accessibilityHint="Retries failed photo uploads"
                 accessibilityLabel="Retry failed uploads"
@@ -336,7 +273,7 @@ export default function MomentForm({
               <Text style={styles.errorText}>{submitError}</Text>
             ) : null}
 
-            {isSaving ? (
+            {saveState === 'saving' ? (
               <View style={styles.submittingRow}>
                 <ActivityIndicator color={sectionColors.moments} />
                 <Text style={styles.submittingText}>Saving moment...</Text>

--- a/components/MomentForm.tsx
+++ b/components/MomentForm.tsx
@@ -69,7 +69,8 @@ function getOptimisticMomentData(
     .map((photo) => ({
       storagePath: photo.storagePath!,
       url: photo.uri,
-    }));
+    }))
+    .slice(0, MAX_IMAGES_PER_UPLOAD);
 
   return {
     coverImage: optimisticPhotos[0]?.url,

--- a/components/ui/AddImageField.tsx
+++ b/components/ui/AddImageField.tsx
@@ -3,25 +3,43 @@ import { baseColors, sectionColors } from '@/theme/colors';
 import { radius } from '@/theme/radius';
 import { space } from '@/theme/space';
 import { text as textTheme } from '@/theme/type';
-import { ImageZoom } from '@likashefqet/react-native-image-zoom';
+import {
+  ImageZoom,
+  type ImageZoomRef,
+} from '@likashefqet/react-native-image-zoom';
 import Constants from 'expo-constants';
 import { Image } from 'expo-image';
 import * as ImagePicker from 'expo-image-picker';
 import { AlertTriangle, Camera, Plus, X } from 'lucide-react-native';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  FlatList,
   LayoutChangeEvent,
   Modal,
   Image as NativeImage,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   Pressable,
   StyleSheet,
   useWindowDimensions,
   View,
   type ViewProps,
 } from 'react-native';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+} from 'react-native-gesture-handler';
+import Animated, {
+  Extrapolation,
+  interpolate,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -36,6 +54,11 @@ const GRID_COLUMNS = 3;
 const GRID_GAP = space.md;
 const VIEWER_HORIZONTAL_PADDING = space.lg;
 const VIEWER_CLOSE_BUTTON_SIZE = 36;
+const VIEWER_REOPEN_COOLDOWN_MS = 300;
+const VIEWER_DISMISS_DISTANCE = 120;
+const VIEWER_DISMISS_VELOCITY = 1000;
+const VIEWER_DISMISS_ACTIVE_OFFSET_Y = 12;
+const VIEWER_DISMISS_FAIL_OFFSET_X = 28;
 
 type ImageDimensions = {
   width: number;
@@ -140,6 +163,134 @@ function getContainedImageSize(
   };
 }
 
+type FullscreenViewerSlideProps = {
+  image: SelectedImage;
+  index: number;
+  isActive: boolean;
+  onZoomStateChange: (isZoomed: boolean) => void;
+  onResolveDimensions: (imageId: string, dimensions: ImageDimensions) => void;
+  resolvedDimensions: ImageDimensions | null;
+  viewerAvailableHeight: number;
+  viewerAvailableWidth: number;
+  windowWidth: number;
+  bottomInset: number;
+};
+
+function FullscreenViewerSlide({
+  image,
+  index,
+  isActive,
+  onZoomStateChange,
+  onResolveDimensions,
+  resolvedDimensions,
+  viewerAvailableHeight,
+  viewerAvailableWidth,
+  windowWidth,
+  bottomInset,
+}: FullscreenViewerSlideProps) {
+  const zoomRef = useRef<ImageZoomRef>(null);
+  const imageDimensions = getImageDimensions(image, resolvedDimensions);
+  const viewerImageSize = getContainedImageSize(
+    imageDimensions,
+    viewerAvailableWidth,
+    viewerAvailableHeight,
+  );
+
+  const syncZoomState = useCallback(() => {
+    if (!isActive) {
+      return;
+    }
+
+    const scale = zoomRef.current?.getInfo().transformations.scale ?? 1;
+
+    onZoomStateChange(scale > 1.01);
+  }, [isActive, onZoomStateChange]);
+
+  useEffect(() => {
+    if (imageDimensions || !image.uri) {
+      return;
+    }
+
+    let isActiveRequest = true;
+
+    NativeImage.getSize(
+      image.uri,
+      (width, height) => {
+        if (!isActiveRequest) {
+          return;
+        }
+
+        onResolveDimensions(image.id, { width, height });
+      },
+      () => {
+        if (!isActiveRequest) {
+          return;
+        }
+
+        onResolveDimensions(image.id, {
+          width: viewerAvailableWidth || 1,
+          height: viewerAvailableHeight || 1,
+        });
+      },
+    );
+
+    return () => {
+      isActiveRequest = false;
+    };
+  }, [
+    image.id,
+    image.uri,
+    imageDimensions,
+    onResolveDimensions,
+    viewerAvailableHeight,
+    viewerAvailableWidth,
+  ]);
+
+  useEffect(() => {
+    if (isActive) {
+      syncZoomState();
+      return;
+    }
+
+    zoomRef.current?.reset();
+  }, [isActive, syncZoomState]);
+
+  return (
+    <View style={[styles.viewerSlide, { width: windowWidth }]}>
+      <View
+        style={[
+          styles.viewerImageFrame,
+          { paddingBottom: bottomInset + space.xl },
+        ]}
+      >
+        <ImageZoom
+          ref={zoomRef}
+          isDoubleTapEnabled
+          maxScale={4}
+          minScale={1}
+          onInteractionEnd={syncZoomState}
+          onResetAnimationEnd={() => {
+            if (!isActive) {
+              return;
+            }
+
+            onZoomStateChange(false);
+          }}
+          resizeMode="contain"
+          style={[
+            styles.viewerImage,
+            {
+              height: viewerImageSize.height,
+              width: viewerImageSize.width,
+            },
+          ]}
+          uri={image.uri}
+        />
+      </View>
+    </View>
+  );
+}
+
 export function AddImageField({
   value,
   onChange,
@@ -157,11 +308,16 @@ export function AddImageField({
   const [isPicking, setIsPicking] = useState(false);
   const [gridWidth, setGridWidth] = useState(0);
   const [activeImageIndex, setActiveImageIndex] = useState<number | null>(null);
+  const [isViewerZoomed, setIsViewerZoomed] = useState(false);
   const [viewerImageDimensions, setViewerImageDimensions] = useState<
     Record<string, ImageDimensions>
   >({});
+  const activeImageIndexRef = useRef<number | null>(null);
+  const viewerReopenBlockedUntilRef = useRef(0);
+  const viewerListRef = useRef<FlatList<SelectedImage>>(null);
   const { height: windowHeight, width: windowWidth } = useWindowDimensions();
   const insets = useSafeAreaInsets();
+  const viewerTranslateY = useSharedValue(0);
   const isEditable = editable ?? Boolean(onChange);
   const showsRemoveButton = isEditable && (showRemoveButton ?? true);
   const resolvedMaxImages =
@@ -176,12 +332,6 @@ export function AddImageField({
     gridWidth > GRID_GAP * (GRID_COLUMNS - 1)
       ? (gridWidth - GRID_GAP * (GRID_COLUMNS - 1)) / GRID_COLUMNS
       : 0;
-  const activeImage =
-    activeImageIndex === null ? null : images[activeImageIndex];
-  const activeImageResolvedDimensions = getImageDimensions(
-    activeImage,
-    activeImage ? (viewerImageDimensions[activeImage.id] ?? null) : null,
-  );
   const viewerAvailableWidth = Math.max(
     windowWidth - VIEWER_HORIZONTAL_PADDING * 2,
     0,
@@ -194,74 +344,84 @@ export function AddImageField({
       space.xl * 3,
     0,
   );
-  const viewerImageSize = getContainedImageSize(
-    activeImageResolvedDimensions,
-    viewerAvailableWidth,
-    viewerAvailableHeight,
+  const viewerBackdropAnimatedStyle = useAnimatedStyle(
+    () => ({
+      opacity: interpolate(
+        Math.abs(viewerTranslateY.value),
+        [0, VIEWER_DISMISS_DISTANCE * 1.5],
+        [1, 0.45],
+        Extrapolation.CLAMP,
+      ),
+    }),
+    [],
   );
+  const viewerContentAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: viewerTranslateY.value }],
+  }));
+
+  useEffect(() => {
+    if (activeImageIndex === null) {
+      activeImageIndexRef.current = null;
+      setIsViewerZoomed(false);
+      viewerTranslateY.value = 0;
+      return;
+    }
+
+    if (images.length === 0) {
+      activeImageIndexRef.current = null;
+      setActiveImageIndex(null);
+      return;
+    }
+
+    if (activeImageIndex > images.length - 1) {
+      const nextIndex = images.length - 1;
+
+      activeImageIndexRef.current = nextIndex;
+      setActiveImageIndex(nextIndex);
+      return;
+    }
+
+    activeImageIndexRef.current = activeImageIndex;
+  }, [activeImageIndex, images.length, viewerTranslateY]);
 
   useEffect(() => {
     if (activeImageIndex === null) {
       return;
     }
 
-    if (images.length === 0) {
-      setActiveImageIndex(null);
-      return;
-    }
-
-    if (activeImageIndex > images.length - 1) {
-      setActiveImageIndex(images.length - 1);
-    }
-  }, [activeImageIndex, images.length]);
-
-  useEffect(() => {
-    if (!activeImage) {
-      return;
-    }
-
-    if (activeImageResolvedDimensions || !activeImage.uri) {
-      return;
-    }
-
-    let isActive = true;
-
-    NativeImage.getSize(
-      activeImage.uri,
-      (width, height) => {
-        if (!isActive) {
-          return;
-        }
-
-        setViewerImageDimensions((current) => ({
-          ...current,
-          [activeImage.id]: { width, height },
-        }));
-      },
-      () => {
-        if (!isActive) {
-          return;
-        }
-
-        setViewerImageDimensions((current) => ({
-          ...current,
-          [activeImage.id]: {
-            width: viewerAvailableWidth || 1,
-            height: viewerAvailableHeight || 1,
-          },
-        }));
-      },
-    );
+    const frame = requestAnimationFrame(() => {
+      viewerListRef.current?.scrollToOffset({
+        animated: false,
+        offset: windowWidth * activeImageIndex,
+      });
+    });
 
     return () => {
-      isActive = false;
+      cancelAnimationFrame(frame);
     };
-  }, [
-    activeImage,
-    activeImageResolvedDimensions,
-    viewerAvailableHeight,
-    viewerAvailableWidth,
-  ]);
+  }, [activeImageIndex, windowWidth]);
+
+  const handleResolveViewerDimensions = useCallback(
+    (imageId: string, dimensions: ImageDimensions) => {
+      setViewerImageDimensions((current) => {
+        const existing = current[imageId];
+
+        if (
+          existing &&
+          existing.width === dimensions.width &&
+          existing.height === dimensions.height
+        ) {
+          return current;
+        }
+
+        return {
+          ...current,
+          [imageId]: dimensions,
+        };
+      });
+    },
+    [],
+  );
 
   function handleGridLayout(event: LayoutChangeEvent) {
     const nextWidth = Math.round(event.nativeEvent.layout.width);
@@ -328,12 +488,81 @@ export function AddImageField({
       return;
     }
 
+    if (Date.now() < viewerReopenBlockedUntilRef.current) {
+      return;
+    }
+
+    setIsViewerZoomed(false);
+    viewerTranslateY.value = 0;
+    activeImageIndexRef.current = index;
     setActiveImageIndex(index);
   }
 
   function handleCloseViewer() {
+    viewerReopenBlockedUntilRef.current =
+      Date.now() + VIEWER_REOPEN_COOLDOWN_MS;
+    activeImageIndexRef.current = null;
+    setIsViewerZoomed(false);
+    viewerTranslateY.value = 0;
     setActiveImageIndex(null);
   }
+
+  function handleViewerScrollEnd(
+    event: NativeSyntheticEvent<NativeScrollEvent>,
+  ) {
+    const currentActiveIndex = activeImageIndexRef.current;
+
+    if (windowWidth <= 0) {
+      return;
+    }
+
+    if (
+      currentActiveIndex === null ||
+      Date.now() < viewerReopenBlockedUntilRef.current
+    ) {
+      return;
+    }
+
+    const nextIndex = Math.round(
+      event.nativeEvent.contentOffset.x / windowWidth,
+    );
+
+    if (!images[nextIndex] || nextIndex === currentActiveIndex) {
+      return;
+    }
+
+    setIsViewerZoomed(false);
+    viewerTranslateY.value = 0;
+    activeImageIndexRef.current = nextIndex;
+    setActiveImageIndex(nextIndex);
+  }
+
+  const viewerDismissGesture = Gesture.Pan()
+    .enabled(activeImageIndex !== null && !isViewerZoomed)
+    .maxPointers(1)
+    .activeOffsetY([
+      -VIEWER_DISMISS_ACTIVE_OFFSET_Y,
+      VIEWER_DISMISS_ACTIVE_OFFSET_Y,
+    ])
+    .failOffsetX([-VIEWER_DISMISS_FAIL_OFFSET_X, VIEWER_DISMISS_FAIL_OFFSET_X])
+    .onUpdate((event) => {
+      viewerTranslateY.value = event.translationY;
+    })
+    .onEnd((event) => {
+      const shouldClose =
+        Math.abs(event.translationY) >= VIEWER_DISMISS_DISTANCE ||
+        Math.abs(event.velocityY) >= VIEWER_DISMISS_VELOCITY;
+
+      if (shouldClose) {
+        runOnJS(handleCloseViewer)();
+        return;
+      }
+
+      viewerTranslateY.value = withSpring(0, {
+        damping: 20,
+        stiffness: 220,
+      });
+    });
 
   function handleRemoveImage(imageId: string) {
     if (!isEditable || !onChange || disabled || isPicking) {
@@ -498,6 +727,10 @@ export function AddImageField({
       >
         <GestureHandlerRootView style={styles.viewerGestureRoot}>
           <View style={styles.viewerOverlay}>
+            <Animated.View
+              pointerEvents="none"
+              style={[styles.viewerBackdrop, viewerBackdropAnimatedStyle]}
+            />
             <Pressable
               accessibilityHint="Closes the photo viewer"
               accessibilityLabel="Close photo viewer"
@@ -506,52 +739,68 @@ export function AddImageField({
               style={StyleSheet.absoluteFill}
             />
 
-            <SafeAreaView edges={['bottom']} style={styles.viewerSafeArea}>
-              <View
-                style={[
-                  styles.viewerTopBar,
-                  { paddingTop: insets.top + space.lg },
-                ]}
+            <GestureDetector gesture={viewerDismissGesture}>
+              <Animated.View
+                style={[styles.viewerContent, viewerContentAnimatedStyle]}
               >
-                <Pressable
-                  accessibilityHint="Closes the photo viewer"
-                  accessibilityLabel="Close photo viewer"
-                  accessibilityRole="button"
-                  hitSlop={space.sm}
-                  onPress={handleCloseViewer}
-                  style={({ pressed }) => [
-                    styles.viewerCloseButton,
-                    pressed ? styles.pressed : null,
-                  ]}
-                >
-                  <X color={baseColors.text} size={18} strokeWidth={2.25} />
-                </Pressable>
-              </View>
-
-              <View
-                style={[
-                  styles.viewerImageFrame,
-                  { paddingBottom: insets.bottom + space.xl },
-                ]}
-              >
-                {activeImage ? (
-                  <ImageZoom
-                    isDoubleTapEnabled
-                    maxScale={4}
-                    minScale={1}
-                    resizeMode="contain"
+                <SafeAreaView edges={['bottom']} style={styles.viewerSafeArea}>
+                  <View
                     style={[
-                      styles.viewerImage,
-                      {
-                        height: viewerImageSize.height,
-                        width: viewerImageSize.width,
-                      },
+                      styles.viewerTopBar,
+                      { paddingTop: insets.top + space.lg },
                     ]}
-                    uri={activeImage.uri}
+                  >
+                    <Pressable
+                      accessibilityHint="Closes the photo viewer"
+                      accessibilityLabel="Close photo viewer"
+                      accessibilityRole="button"
+                      hitSlop={space.sm}
+                      onPress={handleCloseViewer}
+                      style={({ pressed }) => [
+                        styles.viewerCloseButton,
+                        pressed ? styles.pressed : null,
+                      ]}
+                    >
+                      <X color={baseColors.text} size={18} strokeWidth={2.25} />
+                    </Pressable>
+                  </View>
+
+                  <FlatList
+                    ref={viewerListRef}
+                    data={images}
+                    getItemLayout={(_, index) => ({
+                      index,
+                      length: windowWidth,
+                      offset: windowWidth * index,
+                    })}
+                    horizontal
+                    keyExtractor={(image) => image.id}
+                    onMomentumScrollEnd={handleViewerScrollEnd}
+                    pagingEnabled
+                    removeClippedSubviews={false}
+                    renderItem={({ item, index }) => (
+                      <FullscreenViewerSlide
+                        bottomInset={insets.bottom}
+                        image={item}
+                        index={index}
+                        isActive={index === activeImageIndex}
+                        onResolveDimensions={handleResolveViewerDimensions}
+                        onZoomStateChange={setIsViewerZoomed}
+                        resolvedDimensions={
+                          viewerImageDimensions[item.id] ?? null
+                        }
+                        viewerAvailableHeight={viewerAvailableHeight}
+                        viewerAvailableWidth={viewerAvailableWidth}
+                        windowWidth={windowWidth}
+                      />
+                    )}
+                    scrollEnabled={!isViewerZoomed}
+                    showsHorizontalScrollIndicator={false}
+                    style={styles.viewerPager}
                   />
-                ) : null}
-              </View>
-            </SafeAreaView>
+                </SafeAreaView>
+              </Animated.View>
+            </GestureDetector>
           </View>
         </GestureHandlerRootView>
       </Modal>
@@ -669,11 +918,23 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   viewerOverlay: {
+    flex: 1,
+  },
+  viewerBackdrop: {
+    ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(15, 13, 12, 0.96)',
+  },
+  viewerContent: {
     flex: 1,
   },
   viewerTopBar: {
     paddingHorizontal: space.lg,
+  },
+  viewerPager: {
+    flex: 1,
+  },
+  viewerSlide: {
+    flex: 1,
   },
   viewerCloseButton: {
     alignItems: 'center',

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,4 +1,5 @@
 import { baseColors } from '@/theme/colors';
+import { getSaveLabel, type SaveState } from '@/lib/interaction';
 import { Plus } from 'lucide-react-native';
 import { Pressable, StyleSheet } from 'react-native';
 import { Text } from './Text';
@@ -8,6 +9,7 @@ interface ButtonProps extends React.ComponentProps<typeof Pressable> {
   variant?: 'default' | 'round';
   color?: string;
   alignSelf?: 'flex-start' | 'flex-end' | 'center';
+  saveState?: SaveState;
 }
 
 export default function Button({
@@ -15,17 +17,30 @@ export default function Button({
   variant = 'default',
   color,
   alignSelf,
+  disabled,
+  saveState,
+  onPress,
   ...rest
 }: ButtonProps) {
+  const isLocked = disabled || saveState === 'saving' || saveState === 'saved';
+  const resolvedLabel = saveState ? getSaveLabel(saveState, label) : label;
+
   return (
     <Pressable
       {...rest}
-      style={[styles[variant], { backgroundColor: color, alignSelf }]}
+      disabled={isLocked}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles[variant],
+        { alignSelf, backgroundColor: color },
+        pressed && !isLocked ? styles.pressed : null,
+        isLocked ? styles.disabled : null,
+      ]}
     >
       {variant === 'round' ? (
         <Plus color={baseColors.bg} size={28} />
       ) : (
-        <Text style={styles.text}>{label}</Text>
+        <Text style={styles.text}>{resolvedLabel}</Text>
       )}
     </Pressable>
   );
@@ -50,5 +65,11 @@ const styles = StyleSheet.create({
   },
   text: {
     color: baseColors.bg,
+  },
+  pressed: {
+    opacity: 0.80,
+  },
+  disabled: {
+    opacity: 0.45,
   },
 });

--- a/hooks/useEntryForm.ts
+++ b/hooks/useEntryForm.ts
@@ -1,0 +1,185 @@
+import {
+  type SelectedImage,
+  type ImageUploadStatus,
+} from '@/components/ui/AddImageField';
+import {
+  SAVE_SUCCESS_FEEDBACK_MS,
+  triggerErrorFeedback,
+  triggerSuccessFeedback,
+  type SaveState,
+  wait,
+} from '@/lib/interaction';
+import { type ImageBucket, MAX_IMAGES_PER_UPLOAD } from '@/lib/images';
+import { useEffect, useMemo, useState } from 'react';
+import { useImageUpload } from './useImageUpload';
+
+const SAVE_TIMEOUT_MS = 10000;
+const UPLOADING_STATES: ImageUploadStatus[] = ['local', 'uploading'];
+
+type UseEntryFormOptions = {
+  bucket: ImageBucket;
+  initialPhotos: SelectedImage[];
+  onSaved: () => void;
+  saveErrorMessage: string;
+};
+
+function getUploadedPhotos(photos: SelectedImage[]) {
+  return photos
+    .filter(
+      (photo) =>
+        photo.uploadStatus === 'uploaded' && Boolean(photo.storagePath),
+    )
+    .slice(0, MAX_IMAGES_PER_UPLOAD)
+    .map((photo) => ({ storagePath: photo.storagePath! }));
+}
+
+function getFailedUploadMessage(uploadError: string | null) {
+  return uploadError
+    ? `Some photos failed to upload: ${uploadError}`
+    : 'Some photos failed to upload. Remove or retry them before saving.';
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  fallback: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(fallback));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
+}
+
+export function useEntryForm({
+  bucket,
+  initialPhotos,
+  onSaved,
+  saveErrorMessage,
+}: UseEntryFormOptions) {
+  const [photos, setPhotos] = useState(initialPhotos);
+  const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const { startUpload } = useImageUpload({
+    bucket,
+    setImages: setPhotos,
+  });
+  const isUploading = photos.some((photo) =>
+    UPLOADING_STATES.includes(photo.uploadStatus ?? 'uploaded'),
+  );
+  const failedUploads = photos.filter(
+    (photo) => photo.uploadStatus === 'failed',
+  );
+  const uploadedPhotos = useMemo(() => getUploadedPhotos(photos), [photos]);
+  const retryUploadsDisabled = isUploading || isSaving;
+  const submitError =
+    (isUploading ? 'Please wait for photos to finish uploading.' : null) ??
+    saveError;
+  const saveDisabled = isSaving || saveState === 'saved' || isUploading;
+  const firstFailedUploadError =
+    failedUploads.find((photo) => photo.uploadError)?.uploadError ?? null;
+
+  useEffect(() => {
+    if (!saveError && saveState !== 'error') {
+      return;
+    }
+
+    setSaveError(null);
+    if (saveState === 'error') {
+      setSaveState('idle');
+    }
+  }, [photos, saveError, saveState]);
+
+  async function handleRetryFailedUploads() {
+    if (retryUploadsDisabled) {
+      return;
+    }
+
+    setSaveError(null);
+    const result = await startUpload(failedUploads);
+
+    if (result.failedIds.length === 0) {
+      void triggerSuccessFeedback();
+      return;
+    }
+
+    setSaveError(getFailedUploadMessage(firstFailedUploadError));
+    void triggerErrorFeedback();
+  }
+
+  async function handleSave(isValid: boolean, submit: () => Promise<unknown>) {
+    if (isSaving || saveState === 'saved') {
+      return;
+    }
+
+    setHasTriedSubmit(true);
+    setSaveError(null);
+
+    if (!isValid) {
+      setSaveState('error');
+      void triggerErrorFeedback();
+      return;
+    }
+
+    if (isUploading) {
+      setSaveState('idle');
+      return;
+    }
+
+    if (failedUploads.length > 0) {
+      setSaveError(getFailedUploadMessage(firstFailedUploadError));
+      setSaveState('error');
+      void triggerErrorFeedback();
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveState('saving');
+
+    try {
+      await withTimeout(submit(), SAVE_TIMEOUT_MS, saveErrorMessage);
+      setSaveState('saved');
+      void triggerSuccessFeedback();
+      await wait(SAVE_SUCCESS_FEEDBACK_MS);
+      onSaved();
+    } catch (error) {
+      setSaveError(getErrorMessage(error, saveErrorMessage));
+      setSaveState('error');
+      void triggerErrorFeedback();
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return {
+    failedUploads,
+    handleRetryFailedUploads,
+    handleSave,
+    hasTriedSubmit,
+    photos,
+    retryUploadsDisabled,
+    saveDisabled,
+    saveState,
+    setPhotos,
+    startUpload,
+    submitError,
+    uploadedPhotos,
+  };
+}

--- a/hooks/useEntryForm.ts
+++ b/hooks/useEntryForm.ts
@@ -13,7 +13,6 @@ import { type ImageBucket, MAX_IMAGES_PER_UPLOAD } from '@/lib/images';
 import { useEffect, useMemo, useState } from 'react';
 import { useImageUpload } from './useImageUpload';
 
-const SAVE_TIMEOUT_MS = 10000;
 const UPLOADING_STATES: ImageUploadStatus[] = ['local', 'uploading'];
 
 type UseEntryFormOptions = {
@@ -41,29 +40,6 @@ function getFailedUploadMessage(uploadError: string | null) {
 
 function getErrorMessage(error: unknown, fallback: string) {
   return error instanceof Error ? error.message : fallback;
-}
-
-function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  fallback: string,
-): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      reject(new Error(fallback));
-    }, timeoutMs);
-
-    promise.then(
-      (value) => {
-        clearTimeout(timeoutId);
-        resolve(value);
-      },
-      (error) => {
-        clearTimeout(timeoutId);
-        reject(error);
-      },
-    );
-  });
 }
 
 export function useEntryForm({
@@ -154,7 +130,7 @@ export function useEntryForm({
     setSaveState('saving');
 
     try {
-      await withTimeout(submit(), SAVE_TIMEOUT_MS, saveErrorMessage);
+      await submit();
       setSaveState('saved');
       void triggerSuccessFeedback();
       await wait(SAVE_SUCCESS_FEEDBACK_MS);

--- a/hooks/useEvents.ts
+++ b/hooks/useEvents.ts
@@ -43,8 +43,8 @@ export function useCreateEventMutation() {
 
   return useMutation({
     mutationFn: createEvent,
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
         queryKey: eventKeys.all,
       });
     },
@@ -56,8 +56,8 @@ export function useUpdateEventMutation() {
 
   return useMutation({
     mutationFn: updateEvent,
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
         queryKey: eventKeys.all,
       });
     },
@@ -72,7 +72,7 @@ export function useDeleteEventMutation() {
       deleteEvent(eventId, groupId),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: eventKeys.all,
+        queryKey: eventKeys.lists(),
       });
     },
   });

--- a/hooks/useImageUpload.ts
+++ b/hooks/useImageUpload.ts
@@ -24,6 +24,11 @@ type UploadVariables = {
   context: UploadContext;
 };
 
+export type UploadBatchResult = {
+  failedIds: string[];
+  uploadedIds: string[];
+};
+
 export const imageUploadKeys = {
   context: ['image-upload', 'context'] as const,
 };
@@ -53,9 +58,15 @@ export function useImageUpload({ bucket, setImages }: UseImageUploadArgs) {
   );
 
   const startUpload = useCallback(
-    async (newImages: SelectedImage[]) => {
+    async (newImages: SelectedImage[]): Promise<UploadBatchResult> => {
+      const failedIds: string[] = [];
+      const uploadedIds: string[] = [];
+
       if (newImages.length === 0) {
-        return;
+        return {
+          failedIds,
+          uploadedIds,
+        };
       }
 
       setImages((current) =>
@@ -82,7 +93,12 @@ export function useImageUpload({ bucket, setImages }: UseImageUploadArgs) {
               : image,
           ),
         );
-        return;
+        failedIds.push(...newImages.map((image) => image.id));
+
+        return {
+          failedIds,
+          uploadedIds,
+        };
       }
 
       await Promise.all(
@@ -105,6 +121,7 @@ export function useImageUpload({ bucket, setImages }: UseImageUploadArgs) {
                   : existing,
               ),
             );
+            uploadedIds.push(image.id);
           } catch (error) {
             const message =
               error instanceof Error ? error.message : 'Upload failed.';
@@ -120,9 +137,15 @@ export function useImageUpload({ bucket, setImages }: UseImageUploadArgs) {
                   : existing,
               ),
             );
+            failedIds.push(image.id);
           }
         }),
       );
+
+      return {
+        failedIds,
+        uploadedIds,
+      };
     },
     [ensureContext, mutateAsync, queryClient, setImages],
   );

--- a/hooks/useMoments.ts
+++ b/hooks/useMoments.ts
@@ -3,9 +3,161 @@ import {
   deleteMoment,
   getMomentById,
   listMomentsForGroup,
+  type CreateMomentInput,
+  type MomentDetail,
+  type MomentListItem,
+  type MomentDetailPhoto,
+  type UpdateMomentInput,
   updateMoment,
 } from '@/services/moments';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  type QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+type OptimisticMomentData = {
+  coverImage?: string;
+  photos?: MomentDetailPhoto[];
+};
+
+export type CreateMomentMutationInput = CreateMomentInput & {
+  optimistic?: OptimisticMomentData;
+};
+
+export type UpdateMomentMutationInput = UpdateMomentInput & {
+  optimistic?: OptimisticMomentData;
+};
+
+type DeleteMomentMutationInput = {
+  groupId: string;
+  momentId: string;
+};
+
+type MomentMutationContext = {
+  detail?: MomentDetail | null;
+  groupId: string;
+  list?: MomentListItem[];
+  tempId?: string;
+};
+
+function getOccurredOn(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function buildMomentListItem(
+  momentId: string,
+  input: CreateMomentMutationInput | UpdateMomentMutationInput,
+): MomentListItem {
+  const description = input.description.trim();
+  const category = input.momentType.trim();
+
+  return {
+    id: momentId,
+    title: input.title.trim(),
+    description: description.length > 0 ? description : null,
+    category: category.length > 0 ? category : null,
+    occurredOn: getOccurredOn(input.occurredAt),
+    coverImage: input.optimistic?.coverImage,
+  };
+}
+
+function buildMomentDetail(
+  momentId: string,
+  input: CreateMomentMutationInput | UpdateMomentMutationInput,
+): MomentDetail {
+  const description = input.description.trim();
+  const category = input.momentType.trim();
+
+  return {
+    id: momentId,
+    title: input.title.trim(),
+    description: description.length > 0 ? description : null,
+    category: category.length > 0 ? category : null,
+    occurredOn: getOccurredOn(input.occurredAt),
+    photos: input.optimistic?.photos ?? [],
+  };
+}
+
+function replaceMomentInList(
+  list: MomentListItem[],
+  momentId: string,
+  nextMoment: MomentListItem,
+) {
+  const existingIndex = list.findIndex((moment) => moment.id === momentId);
+
+  if (existingIndex === -1) {
+    return [nextMoment, ...list];
+  }
+
+  return list.map((moment) => (moment.id === momentId ? nextMoment : moment));
+}
+
+function getMomentList(queryClient: QueryClient, groupId: string) {
+  return queryClient.getQueryData<MomentListItem[]>(momentKeys.list(groupId));
+}
+
+function getMomentDetail(
+  queryClient: QueryClient,
+  groupId: string,
+  momentId: string,
+) {
+  return queryClient.getQueryData<MomentDetail | null>(
+    momentKeys.detail(momentId, groupId),
+  );
+}
+
+function setMomentList(
+  queryClient: QueryClient,
+  groupId: string,
+  updater: (current: MomentListItem[]) => MomentListItem[],
+) {
+  queryClient.setQueryData<MomentListItem[]>(
+    momentKeys.list(groupId),
+    (current = []) => updater(current),
+  );
+}
+
+function setMomentDetail(
+  queryClient: QueryClient,
+  groupId: string,
+  momentId: string,
+  detail: MomentDetail,
+) {
+  queryClient.setQueryData(momentKeys.detail(momentId, groupId), detail);
+}
+
+function restoreMomentCache(
+  queryClient: QueryClient,
+  context: MomentMutationContext,
+  momentId?: string,
+) {
+  queryClient.setQueryData(momentKeys.list(context.groupId), context.list);
+
+  if (momentId) {
+    queryClient.setQueryData(
+      momentKeys.detail(momentId, context.groupId),
+      context.detail,
+    );
+  }
+}
+
+async function cancelMomentQueries(
+  queryClient: QueryClient,
+  groupId: string,
+  momentId?: string,
+) {
+  await queryClient.cancelQueries({
+    queryKey: momentKeys.list(groupId),
+  });
+
+  if (momentId) {
+    await queryClient.cancelQueries({
+      queryKey: momentKeys.detail(momentId, groupId),
+    });
+  }
+}
 
 export const momentKeys = {
   all: ['moments'] as const,
@@ -44,10 +196,71 @@ export function useMomentDetailQuery(
 export function useCreateMomentMutation() {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: createMoment,
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
+  return useMutation<
+    string,
+    Error,
+    CreateMomentMutationInput,
+    MomentMutationContext
+  >({
+    mutationFn: ({ optimistic: _optimistic, ...input }) => createMoment(input),
+    onMutate: async (input) => {
+      await cancelMomentQueries(queryClient, input.groupId);
+
+      const tempId = `optimistic-moment-${Date.now()}`;
+      const context = {
+        groupId: input.groupId,
+        list: getMomentList(queryClient, input.groupId),
+        tempId,
+      };
+
+      setMomentList(queryClient, input.groupId, (current) => [
+        buildMomentListItem(tempId, input),
+        ...current,
+      ]);
+      setMomentDetail(
+        queryClient,
+        input.groupId,
+        tempId,
+        buildMomentDetail(tempId, input),
+      );
+
+      return context;
+    },
+    onError: (_error, _input, context) => {
+      if (!context) {
+        return;
+      }
+
+      restoreMomentCache(queryClient, context);
+      queryClient.removeQueries({
+        exact: true,
+        queryKey: momentKeys.detail(context.tempId!, context.groupId),
+      });
+    },
+    onSuccess: (momentId, input, context) => {
+      if (!context?.tempId) {
+        void queryClient.invalidateQueries({
+          queryKey: momentKeys.all,
+        });
+        return;
+      }
+
+      const nextMoment = buildMomentListItem(momentId, input);
+
+      setMomentList(queryClient, input.groupId, (current) =>
+        replaceMomentInList(current, context.tempId!, nextMoment),
+      );
+      setMomentDetail(
+        queryClient,
+        input.groupId,
+        momentId,
+        buildMomentDetail(momentId, input),
+      );
+      queryClient.removeQueries({
+        exact: true,
+        queryKey: momentKeys.detail(context.tempId, input.groupId),
+      });
+      void queryClient.invalidateQueries({
         queryKey: momentKeys.all,
       });
     },
@@ -57,10 +270,53 @@ export function useCreateMomentMutation() {
 export function useUpdateMomentMutation() {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: updateMoment,
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
+  return useMutation<
+    string,
+    Error,
+    UpdateMomentMutationInput,
+    MomentMutationContext
+  >({
+    mutationFn: ({ optimistic: _optimistic, ...input }) => updateMoment(input),
+    onMutate: async (input) => {
+      await cancelMomentQueries(queryClient, input.groupId, input.momentId);
+
+      const context = {
+        detail: getMomentDetail(queryClient, input.groupId, input.momentId),
+        groupId: input.groupId,
+        list: getMomentList(queryClient, input.groupId),
+      };
+
+      setMomentList(queryClient, input.groupId, (current) =>
+        replaceMomentInList(
+          current,
+          input.momentId,
+          buildMomentListItem(input.momentId, input),
+        ),
+      );
+      setMomentDetail(
+        queryClient,
+        input.groupId,
+        input.momentId,
+        buildMomentDetail(input.momentId, input),
+      );
+
+      return context;
+    },
+    onError: (_error, input, context) => {
+      if (!context) {
+        return;
+      }
+
+      restoreMomentCache(queryClient, context, input.momentId);
+    },
+    onSuccess: (momentId, input) => {
+      setMomentDetail(
+        queryClient,
+        input.groupId,
+        momentId,
+        buildMomentDetail(momentId, input),
+      );
+      void queryClient.invalidateQueries({
         queryKey: momentKeys.all,
       });
     },
@@ -70,17 +326,38 @@ export function useUpdateMomentMutation() {
 export function useDeleteMomentMutation() {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: ({
-      momentId,
-      groupId,
-    }: {
-      momentId: string;
-      groupId: string;
-    }) => deleteMoment(momentId, groupId),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: momentKeys.all,
+  return useMutation<
+    void,
+    Error,
+    DeleteMomentMutationInput,
+    MomentMutationContext
+  >({
+    mutationFn: ({ momentId, groupId }) => deleteMoment(momentId, groupId),
+    onMutate: async (input) => {
+      await cancelMomentQueries(queryClient, input.groupId, input.momentId);
+
+      const context = {
+        detail: getMomentDetail(queryClient, input.groupId, input.momentId),
+        groupId: input.groupId,
+        list: getMomentList(queryClient, input.groupId),
+      };
+
+      setMomentList(queryClient, input.groupId, (current) =>
+        current.filter((moment) => moment.id !== input.momentId),
+      );
+
+      return context;
+    },
+    onError: (_error, input, context) => {
+      if (!context) {
+        return;
+      }
+
+      restoreMomentCache(queryClient, context, input.momentId);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: momentKeys.lists(),
       });
     },
   });

--- a/lib/interaction.ts
+++ b/lib/interaction.ts
@@ -1,0 +1,78 @@
+import * as Haptics from 'expo-haptics';
+import { Platform } from 'react-native';
+
+export type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+export const SAVE_SUCCESS_FEEDBACK_MS = 480;
+
+function canUseHaptics() {
+  return Platform.OS !== 'web';
+}
+
+export function wait(durationMs: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+}
+
+export function toDateKey(date: Date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+export function getSaveLabel(state: SaveState, idleLabel = 'Save') {
+  switch (state) {
+    case 'saving':
+      return 'Saving...';
+    case 'saved':
+      return 'Saved';
+    case 'error':
+      return 'Retry';
+    case 'idle':
+    default:
+      return idleLabel;
+  }
+}
+
+export async function triggerTapFeedback() {
+  if (!canUseHaptics()) {
+    return;
+  }
+
+  await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+}
+
+export async function triggerSelectionFeedback() {
+  if (!canUseHaptics()) {
+    return;
+  }
+
+  await Haptics.selectionAsync();
+}
+
+export async function triggerSuccessFeedback() {
+  if (!canUseHaptics()) {
+    return;
+  }
+
+  await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+}
+
+export async function triggerErrorFeedback() {
+  if (!canUseHaptics()) {
+    return;
+  }
+
+  await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+}
+
+export async function triggerDestructiveFeedback() {
+  if (!canUseHaptics()) {
+    return;
+  }
+
+  await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+}


### PR DESCRIPTION
Events and moments now behave more like finished app flows without changing the existing layout. Saves move through clearer idle, saving, saved, and retry states, repeated taps are guarded, upload failures surface better feedback, and moment mutations feel faster because list and detail state update optimistically.

This also trims a lot of duplicated interaction code. The shared entry-form flow now owns save state, upload retry handling, haptic timing, and success or error transitions, so the event and moment forms stay focused on their own fields. The moment mutation hook is also easier to follow because the optimistic cache work is pushed into smaller helpers instead of being repeated in each mutation branch.

The fullscreen photo viewer was updated in the same pass so event and moment photos can be browsed by swiping in place. That work stays isolated in the shared image field, which keeps the route screens thinner while still making the viewer behavior consistent across both features.
